### PR TITLE
fix image hrefs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,5 +3,6 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--<repo>--<owner>.hlx.page/
-- After: https://<branch>--<repo>--<owner>.hlx.page/
+- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
+- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
+- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>

--- a/worker/src/util/books.ts
+++ b/worker/src/util/books.ts
@@ -1,21 +1,20 @@
-import type { Book, BookData } from '../types';
+import type { Book, BookData, Context } from '../types';
 
 // loaded by esbuild
 const EMBED_BOOK_DATA: BookData[] = process.env.EMBED_BOOKS as unknown as BookData[];
 
 // eslint-disable-next-line no-underscore-dangle
 let _books: Book[];
-export const getBooks = () => {
+export const getBooks = (ctx: Context) => {
   if (_books) return _books;
   _books = EMBED_BOOK_DATA.map((bookData) => {
     const book: Book = {
       ...bookData,
       match(this: Book, path) {
-        return path.startsWith(`/${this.dita}`);
+        return path.startsWith(`${ctx.env.BASE_PATH || ''}${this.path}`);
       },
-      resolve(this: Book, path) {
-        const relpath = path.substring(this.dita.length + 1);
-        return `${this.path}${relpath}`;
+      resolve(this: Book, relPath) {
+        return `${ctx.env.BASE_PATH || ''}${this.path}${relPath}`;
       },
     };
     return book;
@@ -23,16 +22,19 @@ export const getBooks = () => {
   return _books;
 };
 
-export const resolvePath = (path: string): string | undefined => {
-  const books = getBooks();
-  const book = books.find((one) => one.match(path));
+export const findBook = (path: string, ctx: Context): Book | undefined => {
+  const books = getBooks(ctx);
+  return books.find((one) => one.match(path));
+};
+
+export const resolvePath = (path: string, ctx: Context): string | undefined => {
+  const book = findBook(path, ctx);
   if (!book) return undefined;
   return book.resolve(path);
 };
 
-export const resolveAttributes = (path: string): Record<string, string> => {
-  const books = getBooks();
-  const book = books.find((one) => one.match(path));
+export const resolveAttributes = (path: string, ctx: Context): Record<string, string> => {
+  const book = findBook(path, ctx);
   if (!book) return {};
   return book.attributes || {};
 };


### PR DESCRIPTION
- uses book book path to resolve image src, assumes `_graphics` directory is always inside the book's directory

Test URLs:
-  Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/prisma/prisma-cloud/docs/en/compute/admin-guide-pcee/access-control/rbac
- After: https://maxed-fix-images--prisma-cloud-docs--hlxsites.hlx.page/prisma/prisma-cloud/docs/en/compute/admin-guide-pcee/access-control/rbac
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/prisma/prisma-cloud/docs/en/compute/admin-guide-pcee/access-control/rbac?branch=maxed/fix-images
