### PR TITLE
Preview GH Action

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -26,6 +26,7 @@ jobs:
           json_raw_format: true
           files: |
             docs/**/*.adoc
+            docs/**/book.yml
 
       - name: Show preview if any *.adoc or book.yml in the docs folder change
         if: steps.changed-files-specific.outputs.any_changed == 'true'

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,42 @@
+name: Preview changed docs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    name: Preview changed-files
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Get changed files in the docs folder
+        id: changed-files-specific
+        uses: tj-actions/changed-files@v35
+        with:
+          json: true
+          json_raw_format: true
+          files: |
+            docs/**/*.adoc
+            docs/**/book.yml
+
+      - name: Show preview if any *.adoc or book.yml in the docs folder change
+        if: steps.changed-files-specific.outputs.any_changed == 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+
+            const { default: previewChanges } = await import('${{ github.workspace }}/bin/preview-changes.js')
+
+            await previewChanges({
+              github,
+              context,
+              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }}
+            });
+
+
+

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -13,6 +13,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm ci
 
       - name: Get changed files in the docs folder
         id: changed-files-specific
@@ -22,21 +26,17 @@ jobs:
           json_raw_format: true
           files: |
             docs/**/*.adoc
-            docs/**/book.yml
 
       - name: Show preview if any *.adoc or book.yml in the docs folder change
         if: steps.changed-files-specific.outputs.any_changed == 'true'
         uses: actions/github-script@v6
         with:
           script: |
-
             const { default: previewChanges } = await import('${{ github.workspace }}/bin/preview-changes.js')
 
             await previewChanges({
               github,
               context,
-              changes: ${{ steps.changed-files-specific.outputs.all_changed_files }}
+              glob,
+              changes: ${{ steps.changed-files-specific.outputs.all_modified_files }}
             });
-
-
-

--- a/bin/preview-changes.js
+++ b/bin/preview-changes.js
@@ -18,6 +18,7 @@ export default async function previewChanges({
   const host = 'https://main--prisma-cloud-docs-website--hlxsites.hlx.page';
   const fallbackPath = '/prisma/prisma-cloud/en';
   const branch = context.payload.pull_request.head.ref;
+  const adocChanges = changes.filter((change) => change.endsWith('.adoc'));
 
   const bookGlobber = await glob.create('docs/**/book.yml');
   const books = await bookGlobber.glob();
@@ -64,7 +65,7 @@ export default async function previewChanges({
   // Remove "docs" and ".adoc" from path
   const cleanChangePath = (file) => file.slice(4, -5);
 
-  let body = changes.length ? `Preview URL(s):\n\n${changes.map((change) => `- ${host}/prisma/prisma-cloud${cleanChangePath(change)}?branch=${branch}`).join('\n')}`
+  let body = adocChanges.length ? `Preview URL(s):\n\n${adocChanges.map((change) => `- ${host}/prisma/prisma-cloud${cleanChangePath(change)}?branch=${branch}`).join('\n')}`
     : `Default Preview URL: ${host}${fallbackPath}?branch=${branch}`;
 
   if (missingReferences.length) {

--- a/bin/preview-changes.js
+++ b/bin/preview-changes.js
@@ -1,0 +1,30 @@
+/**
+ * Generates preview URLs as GitHub comments for adoc changes
+ * or displays a default preview URL if only book changes
+ *
+ * @param github
+ * @param context
+ * @param changes
+ * @returns {Promise<void>}
+ */
+export default async function previewChanges({ github, context, changes }) {
+  const host = 'https://main--prisma-cloud-docs-website--hlxsites.hlx.page';
+  const fallbackPath = '/prisma/prisma-cloud/en';
+  const branch = context.payload.pull_request.head.ref;
+
+  // We only care about adoc changes for preview urls
+  const adocChanges = changes.filter((change) => change.endsWith('.adoc'));
+  // Remove "docs" and ".adoc" from path
+  const cleanPath = (file) => file.slice(4, -5);
+
+  await github.rest.issues.createComment({
+    issue_number: context.issue.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+    body: adocChanges.length ? `
+Preview URL(s):
+    
+${adocChanges.map((change) => `- ${host}/prisma/prisma-cloud${cleanPath(change)}?branch=${branch}`).join('\n')}`
+      : `Default Preview URL: ${host}${fallbackPath}?branch=${branch}`,
+  });
+}

--- a/bin/preview-changes.js
+++ b/bin/preview-changes.js
@@ -1,30 +1,86 @@
+import fs from 'node:fs';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import yaml from 'js-yaml';
+
 /**
  * Generates preview URLs as GitHub comments for adoc changes
  * or displays a default preview URL if only book changes
  *
  * @param github
  * @param context
+ * @param glob
  * @param changes
  * @returns {Promise<void>}
  */
-export default async function previewChanges({ github, context, changes }) {
+export default async function previewChanges({
+  github, context, glob, changes,
+}) {
   const host = 'https://main--prisma-cloud-docs-website--hlxsites.hlx.page';
   const fallbackPath = '/prisma/prisma-cloud/en';
   const branch = context.payload.pull_request.head.ref;
 
-  // We only care about adoc changes for preview urls
-  const adocChanges = changes.filter((change) => change.endsWith('.adoc'));
+  const bookGlobber = await glob.create('docs/**/book.yml');
+  const books = await bookGlobber.glob();
+
+  const adocGlobber = await glob.create('docs/**/*.adoc');
+  const adocs = await adocGlobber.glob();
+
+  // Find all references adoc files in books
+  const adocReferences = new Set();
+  const normalizePath = (path) => path.toLowerCase().replaceAll('_', '-');
+  const buildAdocReferencePath = (doc, currentPath) => {
+    if (doc.file) {
+      currentPath.push(normalizePath(doc.file));
+      return currentPath.join('/');
+    }
+
+    if (doc.dir) {
+      currentPath.push(normalizePath(doc.dir));
+    }
+
+    if (doc.topics) {
+      doc.topics.forEach((topic) => {
+        const path = buildAdocReferencePath(topic, [...currentPath]);
+        if (path) {
+          adocReferences.add(path);
+        }
+      });
+    }
+
+    return null;
+  };
+
+  books.forEach((book) => {
+    const docs = yaml.loadAll(fs.readFileSync(book).toString()).filter((doc) => doc?.kind === 'chapter');
+    docs.forEach((doc) => {
+      buildAdocReferencePath(doc, book.split('/').slice(0, -1));
+    });
+  });
+
+  // Compare adoc files with adoc referenced in books
+  const missingReferences = [...adocReferences]
+    .filter((adocReference) => !adocs.includes(adocReference));
+
   // Remove "docs" and ".adoc" from path
-  const cleanPath = (file) => file.slice(4, -5);
+  const cleanChangePath = (file) => file.slice(4, -5);
+
+  let body = changes.length ? `Preview URL(s):\n\n${changes.map((change) => `- ${host}/prisma/prisma-cloud${cleanChangePath(change)}?branch=${branch}`).join('\n')}`
+    : `Default Preview URL: ${host}${fallbackPath}?branch=${branch}`;
+
+  if (missingReferences.length) {
+    // Remove home/runner/work/repo/dir
+    const cleanRefPath = (ref) => ref.split('/').slice(6).join('/');
+
+    const buildGHLink = (path) => `https://github.com/${context.payload.pull_request.base.repo.full_name}/tree/${branch}/${cleanRefPath(path)}`;
+
+    body += `\n\nWarning: ${missingReferences.length} missing adoc reference(s) found:\n\n`;
+    body += `${missingReferences.map((missingReference) => `- <a href="${buildGHLink(missingReference)}" target="_blank">${cleanRefPath(missingReference)}</a>`).join('\n')}`;
+  }
 
   await github.rest.issues.createComment({
     issue_number: context.issue.number,
     owner: context.repo.owner,
     repo: context.repo.repo,
-    body: adocChanges.length ? `
-Preview URL(s):
-    
-${adocChanges.map((change) => `- ${host}/prisma/prisma-cloud${cleanPath(change)}?branch=${branch}`).join('\n')}`
-      : `Default Preview URL: ${host}${fallbackPath}?branch=${branch}`,
+    body,
   });
 }


### PR DESCRIPTION
Related to https://github.com/hlxsites/prisma-cloud-docs-website/issues/53

Adds a new CI workflow that triggers on PRs to show preview URLs for adoc and book changes and warns about missing adoc references in books. 

Example output: 
 
<img width="928" alt="Screenshot 2023-06-20 at 15 48 11" src="https://github.com/hlxsites/prisma-cloud-docs/assets/6012307/c0773a9d-8404-4dfb-a4b3-38ef17d98899">

