### PR TITLE
Fix book.yml for use cases book

### DIFF
--- a/docs/en/enterprise-edition/use-cases/book.yml
+++ b/docs/en/enterprise-edition/use-cases/book.yml
@@ -26,7 +26,7 @@ topics:
   - name: Discover Sensitive Data  in Data Stores
     file: discover-sensitive-data-in-datastores.adoc
   - name: Discover and Protect API Endpoints
-    file: discover-api-endpoints-and-risks.adoc
+    file: discover-and-protect-api-endpoints.adoc
   - name: Tailor Prisma Cloud to Match your Security Needs
     file: tailor-prisma-cloud-to-match-your-security-needs.adoc
 ---


### PR DESCRIPTION
book.yml points to the wrong adoc file, so it doesn't load.

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=ian-fix-use-case
