### PR TITLE
image tweaks

### DIFF
--- a/worker/src/util/adoc2html.ts
+++ b/worker/src/util/adoc2html.ts
@@ -315,7 +315,10 @@ class FranklinConverter implements AdocTypes.Converter {
         };
         extractSize('width');
         extractSize('height');
-        return /* html */`<img src="${href}" alt="${node.getAttribute('alt') as string || ''}"${sizes.length ? `${sizes.join(' ')}` : ''}>`;
+        return /* html */`\
+<picture>
+  <img src="${href}" alt="${node.getAttribute('alt') as string || ''}"${sizes.length ? `${sizes.join(' ')}` : ''}>
+</picture>`;
       },
       table: (node) => {
         const title = node.getTitle();

--- a/worker/src/util/adoc2html.ts
+++ b/worker/src/util/adoc2html.ts
@@ -296,6 +296,7 @@ class FranklinConverter implements AdocTypes.Converter {
         const result = /* html */`<li>${text ? `<p>${text || ''}</p>${content || ''}` : ''}</li>`;
         return result;
       },
+      inline_image: (node) => this.templates.image(node as AdocTypes.AbstractBlock),
       image: (node) => {
         const src = node.getAttribute('target') as string | undefined;
         if (!src) {


### PR DESCRIPTION
- wrap imgs in pictures
  - this shouldn't change anything in the published pages, it just makes dev mode more similar to live by more closely matching the output from Franklin
-  add `inline_image` template type

fix https://github.com/hlxsites/prisma-cloud-docs-website/issues/219