### PR TITLE
Update view-respond-to-prisma-cloud-alerts.adoc

### DIFF
--- a/docs/en/enterprise-edition/content-collections/alerts/view-respond-to-prisma-cloud-alerts.adoc
+++ b/docs/en/enterprise-edition/content-collections/alerts/view-respond-to-prisma-cloud-alerts.adoc
@@ -169,7 +169,8 @@ If you want to investigate further, use the *Investigate* link for the automatic
 +
 When the issue is addressed, the alert is moved to a Pending Resolution or Resolved state, and the risk is addressed.
 +
-//NOTE: When you select Fix in Code, it can take up to a minute to submit the PR to the VCS repository. (VCE-24181 based on Darwin Go/No-Go meeting from Tal)
+NOTE: The process of submitting a PR to fix the issue directly in code is an offline process. When the process completes and the PR is submitted, the button will update to *View Details* and you can access the link to view the PR in your VCS.
+//BCE-24181 and RLP-117660
 
 . *Auto-remediate alerts.*
 


### PR DESCRIPTION
added the description for RLP-117660


Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=fix-in-code
