### PR TITLE
[PCCE AG] 30 and 31 update aws-security-hub.adoc for CWP-39394

### DIFF
--- a/docs/en/compute-edition/30/admin-guide/alerts/aws-security-hub.adoc
+++ b/docs/en/compute-edition/30/admin-guide/alerts/aws-security-hub.adoc
@@ -26,8 +26,7 @@ You will need the service account's access key ID and secret access key to integ
 .. Accept findings from Palo Alto Networks: Prisma Cloud Compute.
 +
 See https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-integrations-managing.html[AWS documentation]
-+
-NOTE: Prisma Cloud integration with Security Hub fails for US Gov regions.
+
 
 // == Configuring alerts
 //

--- a/docs/en/compute-edition/31/admin-guide/alerts/aws-security-hub.adoc
+++ b/docs/en/compute-edition/31/admin-guide/alerts/aws-security-hub.adoc
@@ -26,8 +26,7 @@ You will need the service account's access key ID and secret access key to integ
 .. Accept findings from Palo Alto Networks: Prisma Cloud Compute.
 +
 See https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-integrations-managing.html[AWS documentation]
-+
-NOTE: Prisma Cloud integration with Security Hub fails for US Gov regions.
+
 
 // == Configuring alerts
 //


### PR DESCRIPTION
removed the note that AWS Security Hub integration fails for US Gov region because we fixed it in CWP-39394; PCSUP-9241

Documented in 30.00 RN

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
