### PR TITLE
[RN PCEE]  for CVE-2023-44487 update to features-introduced-in-oct

### DIFF
--- a/docs/en/enterprise-edition/rn/prisma-cloud-release-info/features-introduced-in-2023/features-introduced-in-october-2023.adoc
+++ b/docs/en/enterprise-edition/rn/prisma-cloud-release-info/features-introduced-in-2023/features-introduced-in-october-2023.adoc
@@ -6,6 +6,7 @@ Learn what's new on Prisma™ Cloud in October 2023.
 === New Features Introduced in October 2023
 
 * <<new-features1>>
+* <<security-fix1>>
 * <<api-ingestions1>>
 * <<new-policies1>>
 * <<policy-updates1>>
@@ -200,6 +201,30 @@ To review a list of supported regions, select *Inventory > Assets*, and choose C
 image::aws-israel-region.png[]
 
 |===
+
+[#security-fix1]
+=== Security Fix
+
+[cols="40%a,60%a"]
+|===
+
+|HTTP/2 Rapid Reset Attack Vulnerability (CVE-2023-44487)
+//also listed in /classic-releases/prisma-cloud-compute-release-information/features-introduced-in-compute-october-2023
+
+tt:[*_Secure the Runtime_*]
+
+tt:[*_30.02.137_*]
+|This security update in v31.02.137 for *Runtime Security* addresses the HTTP/2 Rapid Reset Attack Vulnerability (CVE-2023-44487). 
+
+. Go updated from 1.20.8 to 1.20.10 (https://go.dev/doc/devel/release#go1.20.10). 
+
+. Go package "golang.org/x/net" was updated to version 0.17.0 (https://github.com/advisories/GHSA-4374-p667-p6c8). 
+
+. The "nghttp2" package (installed in the Defender/Console images) updated by Red Hat (https://access.redhat.com/errata/RHSA-2023:5837). 
+
+*Action* - You do not need to make any updates to Compute console or the deployed Defenders.
+|===
+
 
 [#api-ingestions1]
 === API Ingestions


### PR DESCRIPTION


HTTP/2 Rapid Reset Attack Vulnerability (CVE-2023-44487) added in october in addition to the Classic RN for Compute.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=update-cve-rn
