### PR TITLE
Fixes typo: "garnular" to "granular"

### DIFF
--- a/docs/en/classic/rql-reference/rql-reference/iam-query/iam-query-conditions.adoc
+++ b/docs/en/classic/rql-reference/rql-reference/iam-query/iam-query-conditions.adoc
@@ -1,13 +1,13 @@
 [#iddf81c4c2-eb03-46e9-9f70-8065ba08c4f7]
 == IAM Query Conditions
 
-Get more garnular search results in your IAM queries, by applying conditions to the `config from iam where` query in your RQL search. Use conditions to minimize the exposure of a resource based policy by making it available only to an organization or specific account, or use it to minimize the access to a machine (EC2 instances or Lambda functions); for example, if a machine has publicly available permissions, you can add a condition to enable actions only to a specific IP address. 
+Get more granular search results in your IAM queries, by applying conditions to the `config from iam where` query in your RQL search. Use conditions to minimize the exposure of a resource based policy by making it available only to an organization or specific account, or use it to minimize the access to a machine (EC2 instances or Lambda functions); for example, if a machine has publicly available permissions, you can add a condition to enable actions only to a specific IP address. 
 
 xref:iam-query-attributes.adoc#idd31fd7aa-bbe1-4353-b872-d89d688dfc45[IAM Query Attributes] also includes the `grantedby.cloud.condition` attribute that assists with permissions queries where the policy statement may or may not contain conditions. For instance, the example below filters all results with the source IP address:
 
 `config from iam where grantedby.cloud.policy.condition('aws:sourceIP') does not exist` 
 
-Several additional operators are also supported to give you more flexibility on how filters are applied. The examples below show how they can be used with the  `config from iam where` query to apply conditions.
+Several additional operators are also supported to give you more flexibility on how filters are applied. The examples below show how they can be used with the `config from iam where` query to apply conditions.
 
 [cols="40%a,40%a,19%a"]
 |===


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://docs.prismacloud.io/en/classic/rql-reference/rql-reference/iam-query/iam-query-conditions
- After: https://docs.prismacloud.io/en/classic/rql-reference/rql-reference/iam-query/iam-query-conditions
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
