### PR TITLE
[AppSec Policy Ref Guide] Commenting out SAST Policies

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/book.yml
+++ b/docs/en/enterprise-edition/policy-reference/book.yml
@@ -2533,371 +2533,371 @@ topics:
   - name: Public and private repositories connected to shared CI system
     file: cp-pub-private-repo-connect-share-ci-system.adoc
 ---
-kind: chapter
-name: SAST Policies
-dir: sast-policies
-topics:
-- name: SAST Policies
-  file: sast-policies.adoc
-- name: Java policies
-  dir: java-policies
-  topics:
-  - name: SAST Java Policy Index
-    file: sast-java-policy-index.adoc
-  - name: Improper neutralization of input during web page generation ('Cross-site
-      Scripting')
-    file: sast-policy-1.adoc
-  - name: Cleartext Transmission of Sensitive Information
-    file: sast-policy-102.adoc
-  - name: Collapse of data into unsafe value
-    file: sast-policy-103.adoc
-  - name: Cross-Site Request Forgery (CSRF)
-    file: sast-policy-104.adoc
-  - name: Deserialization of untrusted data
-    file: sast-policy-105.adoc
-  - name: Deserialization of Untrusted Data
-    file: sast-policy-106.adoc
-  - name: External Control of System or Configuration Setting
-    file: sast-policy-107.adoc
-  - name: External control of system or configuration setting
-    file: sast-policy-108.adoc
-  - name: Improper authentication
-    file: sast-policy-109.adoc
-  - name: Improper certificate validation
-    file: sast-policy-110.adoc
-  - name: Improper certificate validation
-    file: sast-policy-111.adoc
-  - name: Improper control of generation of code ('Code Injection')
-    file: sast-policy-112.adoc
-  - name: Improper control of generation of code ('Code Injection')
-    file: sast-policy-113.adoc
-  - name: Improper Handling of Unicode Encoding
-    file: sast-policy-114.adoc
-  - name: Improper Input Validation
-    file: sast-policy-115.adoc
-  - name: Improper Input Validation
-    file: sast-policy-116.adoc
-  - name: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-    file: sast-policy-117.adoc
-  - name: Improper neutralization of CRLF sequences ('CRLF Injection')
-    file: sast-policy-118.adoc
-  - name: Improper neutralization of data within XPath expressions ('XPath Injection')
-    file: sast-policy-119.adoc
-  - name: Integrity of the data during transmission is not being verified
-    file: sast-policy-12.adoc
-  - name: Improper neutralization of CRLF sequences ('CRLF Injection')
-    file: sast-policy-120.adoc
-  - name: Improper neutralization of special elements used in a command
-    file: sast-policy-121.adoc
-  - name: Improper neutralization of special elements used in an expression language statement ('Expression Language Injection')
-    file: sast-policy-122.adoc
-  - name: Improper neutralization of special elements used in an OS command ('OS Command Injection')
-    file: sast-policy-123.adoc
-  - name: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
-    file: sast-policy-124.adoc
-  - name: Utilizing a class that isn't primitive in Java RMI could lead to a vulnerability associated with insecure deserialization.
-    file: sast-policy-125.adoc
-  - name: Improper privilege management
-    file: sast-policy-126.adoc
-  - name: Improper restriction of XML external entity reference ('XXE')
-    file: sast-policy-127.adoc
-  - name: Improper restriction of XML external entity reference ('XXE')
-    file: sast-policy-128.adoc
-  - name: Improper validation of certificate with host mismatch
-    file: sast-policy-129.adoc
-  - name: Unsafe custom MessageDigest is implemented
-    file: sast-policy-13.adoc
-  - name: Inadequate encryption strength
-    file: sast-policy-130.adoc
-  - name: Inadequate encryption strength
-    file: sast-policy-131.adoc
-  - name: Inadequate encryption strength
-    file: sast-policy-132.adoc
-  - name: 'Incorrect behavior order: validate before canonicalize'
-    file: sast-policy-133.adoc
-  - name: Incorrect permission assignment for critical resource
-    file: sast-policy-134.adoc
-  - name: Incorrect Permission Assignment for Critical Resource
-    file: sast-policy-135.adoc
-  - name: Incorrect type conversion or cast
-    file: sast-policy-136.adoc
-  - name: Information exposure through an error message
-    file: sast-policy-137.adoc
-  - name: Information exposure through an error message
-    file: sast-policy-138.adoc
-  - name: Missing authentication for critical function (database)
-    file: sast-policy-139.adoc
-  - name: Unsafe use of Cross-Origin Resource Sharing (CORS)
-    file: sast-policy-14.adoc
-  - name: Missing authentication for critical function (LDAP)
-    file: sast-policy-140.adoc
-  - name: Permissive Cross-domain Policy with Untrusted Domains
-    file: sast-policy-141.adoc
-  - name: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-    file: sast-policy-142.adoc
-  - name: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
-    file: sast-policy-143.adoc
-  - name: Sensitive cookie without 'HttpOnly' flag
-    file: sast-policy-144.adoc
-  - name: Server-Side Request Forgery (SSRF)
-    file: sast-policy-145.adoc
-  - name: URL Redirection to Untrusted Site ('Open Redirect')
-    file: sast-policy-147.adoc
-  - name: Use of a broken or risky cryptographic algorithm
-    file: sast-policy-148.adoc
-  - name: Use of a broken or risky cryptographic algorithm (SHA1/MD5)
-    file: sast-policy-149.adoc
-  - name: Unsafe use of hazelcast symmetric encryption
-    file: sast-policy-15.adoc
-  - name: Use of externally-controlled format string
-    file: sast-policy-150.adoc
-  - name: Unencrypted payload with JWT
-    file: sast-policy-151.adoc
-  - name: Use of insufficiently random values
-    file: sast-policy-155.adoc
-  - name: Use of RSA algorithm without OAEP
-    file: sast-policy-156.adoc
-  - name: Cookie created without HttpOnly flag
-    file: sast-policy-16.adoc
-  - name: Permissive cross-domain policy with untrusted domains
-    file: sast-policy-162.adoc
-  - name: Improper neutralization of special elements in output used by a downstream component ('Injection')
-    file: sast-policy-163.adoc
-  - name: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
-    file: sast-policy-164.adoc
-  - name: Improper Neutralization of Special Elements in Data Query Logic
-    file: sast-policy-165.adoc
-  - name: Unsafe DES algorithm used
-    file: sast-policy-17.adoc
-  - name: Expression injection (OGNL)
-    file: sast-policy-171.adoc
-  - name: Improper neutralization of special elements used in an LDAP query ('LDAP Injection')
-    file: sast-policy-172.adoc
-  - name: Encryption keys with less than 128 bits
-    file: sast-policy-18.adoc
-  - name: Cookie created without Secure flag set
-    file: sast-policy-19.adoc
-  - name: Cookie stored for an extended period of time
-    file: sast-policy-20.adoc
-  - name: Cookie contains sensitive session info
-    file: sast-policy-21.adoc
-  - name: Trust Boundary is Violated
-    file: sast-policy-22.adoc
-  - name: Security of REST web service is not analyzed
-    file: sast-policy-23.adoc
-  - name: File Creation in Publicly Shared Directories
-    file: sast-policy-24.adoc
-  - name: CSRF is Disabled
-    file: sast-policy-25.adoc
-  - name: Authorization is not robust
-    file: sast-policy-26.adoc
-  - name: Pathname input not restricted
-    file: sast-policy-43.adoc
-  - name: File path not validated in file uploads
-    file: sast-policy-44.adoc
-  - name: Pathname not restricted in HTTP requests
-    file: sast-policy-45.adoc
-  - name: File path not validated for file writes
-    file: sast-policy-46.adoc
-  - name: Missing validation for paths when processing style sheets
-    file: sast-policy-47.adoc
-  - name: Unrestricted directory for pathname construction from HTTP requests
-    file: sast-policy-48.adoc
-  - name: Unrestricted pathnames from HTTP requests
-    file: sast-policy-49.adoc
-  - name: Improper neutralization of argument delimiters in a command ('Argument Injection')
-    file: sast-policy-7.adoc
-  - name: Files or directories accessible to external parties
-    file: sast-policy-8.adoc
-  - name: Improper neutralization of CRLF sequences in HTTP headers ('HTTP Response Splitting')
-    file: sast-policy-9.adoc
-- name: Javascript policies
-  dir: javascript-policies
-  topics:
-  - name: SAST JavaScript Policy Index
-    file: sast-javascript-policy-index.adoc
-  - name: Insecure SSL Server Identity Verification Disabled
-    file: sast-policy-101.adoc
-  - name: Ensure Usage of JWT Algo
-    file: sast-policy-146.adoc
-  - name: Sensitive Data Logging
-    file: sast-policy-153.adoc
-  - name: Cross-Site Request Forgery (CSRF)
-    file: sast-policy-157.adoc
-  - name: Improper restriction of operations within the bounds of a memory buffer
-    file: sast-policy-158.adoc
-  - name: Incorrect regular expression
-    file: sast-policy-159.adoc
-  - name: Information Exposure Through an Error Message
-    file: sast-policy-160.adoc
-  - name: Observable timing discrepancy
-    file: sast-policy-161.adoc
-  - name: Escape markup is removed leading to risk for XSS
-    file: sast-policy-27.adoc
-  - name: CSRF is not used before `methodOverride`
-    file: sast-policy-28.adoc
-  - name: Calls to fs functions that take a non Literal value as the filename parameter
-    file: sast-policy-29.adoc
-  - name: Bracket object notation with user input
-    file: sast-policy-30.adoc
-  - name: Insecure use of crypto.pseudoRandomBytes
-    file: sast-policy-31.adoc
-  - name: Creating temp tile done with insecure permissions
-    file: sast-policy-32.adoc
-  - name: Encryption Keys are less than 16 bytes
-    file: sast-policy-33.adoc
-  - name: Hash used without salt
-    file: sast-policy-34.adoc
-  - name: Use of RSA Algorithm without Optimal Asymmetric Encryption Padding (OAEP)
-    file: sast-policy-35.adoc
-  - name: Superuser port is set
-    file: sast-policy-36.adoc
-  - name: Insecure use of weak hashing algorithms
-    file: sast-policy-38.adoc
-  - name: Use of insecure HTTP connections
-    file: sast-policy-39.adoc
-  - name: Use of insecure HTTP Connections with Axios
-    file: sast-policy-40.adoc
-  - name: Insecure use of `eval` with non-string parameters
-    file: sast-policy-41.adoc
-  - name: Insecure use of `new Buffer()`
-    file: sast-policy-42.adoc
-  - name: Insecure communication using postMessage and event listeners
-    file: sast-policy-74.adoc
-  - name: Encryption algorithm not using secure modes and padding
-    file: sast-policy-75.adoc
-  - name: Risk of Regular Expression Denial of Service (ReDoS)
-    file: sast-policy-76.adoc
-  - name: Weak SSL/TLS protocols
-    file: sast-policy-77.adoc
-  - name: Restrict Unnecessary Powerful Browser Features
-    file: sast-policy-78.adoc
-  - name: Prevent Public Network Access to Cloud Resources
-    file: sast-policy-79.adoc
-  - name: Enforce HTTPS Access for S3 Buckets
-    file: sast-policy-80.adoc
-  - name: Prevent OS Command Argument Injections
-    file: sast-policy-81.adoc
-  - name: Complex/formatted SQL query
-    file: sast-policy-83.adoc
-  - name: AngularJS misconfiguration dangerous protocol allowed
-    file: sast-policy-84.adoc
-  - name: AngularJS Misconfiguration Strict Contextual Escaping Disabled
-    file: sast-policy-85.adoc
-  - name: Detection of XSS vulnerability
-    file: sast-policy-92.adoc
-  - name: Cookie Security Overly Permissive Samesite Attribute
-    file: sast-policy-95.adoc
-- name: Python policies
-  dir: python-policies
-  topics:
-  - name: Encryption keys below 2048 bit
-    file: sast-policy-10.adoc
-  - name: Improper Check or Handling of Exceptional Conditions
-    file: sast-policy-100.adoc
-  - name: Use of module setting superuser port
-    file: sast-policy-11.adoc
-  - name: Hardcoded passwords are being used
-    file: sast-policy-152.adoc
-  - name: Unsanitized path input from an HTTP parameter is being opened
-    file: sast-policy-154.adoc
-  - name: Improper Check or Handling of Exceptional Conditions
-    file: sast-policy-166.adoc
-  - name: Use of Insufficiently Random Values
-    file: sast-policy-167.adoc
-  - name: Improper Control of Generation of Code ('Code Injection')
-    file: sast-policy-168.adoc
-  - name: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
-    file: sast-policy-169.adoc
-  - name: Improper Neutralization of Wildcards or Matching Symbols
-    file: sast-policy-170.adoc
-  - name: Unsafe use of 'exec' command
-    file: sast-policy-2.adoc
-  - name: chmod sets a permissive mask on file
-    file: sast-policy-3.adoc
-  - name: Use of insecure IPMI-related modules
-    file: sast-policy-37.adoc
-  - name: Improper handling of checking for unusual or exceptional conditions
-    file: sast-policy-4.adoc
-  - name: Unsanitized input from data from a remote resource flows into os.system
-    file: sast-policy-48.adoc
-  - name: Publicly exposed servers
-    file: sast-policy-5.adoc
-  - name: XML Parsers exposed to XXE Vulnerabilities
-    file: sast-policy-50.adoc
-  - name: Request exposed to SQL injection
-    file: sast-policy-51.adoc
-  - name: User input not protected against NoSQL injection
-    file: sast-policy-52.adoc
-  - name: Not using HttpOnly flag when setting cookies
-    file: sast-policy-53.adoc
-  - name: JWTs are not properly verified before decoding
-    file: sast-policy-54.adoc
-  - name: Weak cryptographic algorithm used
-    file: sast-policy-55.adoc
-  - name: CSRF protections disabled
-    file: sast-policy-56.adoc
-  - name: Improper logger configuration
-    file: sast-policy-57.adoc
-  - name: Untrusted data unsafely deserialized
-    file: sast-policy-58.adoc
-  - name: Encryption algorithms used with an insecure mode or padding
-    file: sast-policy-59.adoc
-  - name: Use of hardcoded passwords in Python code
-    file: sast-policy-6.adoc
-  - name: HTML Autoescape Mechanism Should Not Be Globally Disabled
-    file: sast-policy-60.adoc
-  - name: LDAP Queries Should Not Be Vulnerable to Injection Attacks
-    file: sast-policy-61.adoc
-  - name: Logging Should Not Be Vulnerable to Injection Attacks
-    file: sast-policy-62.adoc
-  - name: Sending Emails is Security-Sensitive
-    file: sast-policy-63.adoc
-  - name: Server Hostnames Should not verified during SSL/TLS connections
-    file: sast-policy-64.adoc
-  - name: Inadequate Encryption Strength
-    file: sast-policy-65.adoc
-  - name: LDAP anonymous binds are used
-    file: sast-policy-66.adoc
-  - name: Weak SSL/TLS protocol used
-    file: sast-policy-67.adoc
-  - name: Weak SSL/TLS protocol used
-    file: sast-policy-68.adoc
-  - name: Files and directories are assigned loose permissions
-    file: sast-policy-69.adoc
-  - name: Improper Authorization in Handler for Custom URL Scheme
-    file: sast-policy-70.adoc
-  - name: Insecure use of no password or weak password when connecting to a database
-    file: sast-policy-71.adoc
-  - name: Hash functions used without an unpredictable salt
-    file: sast-policy-72.adoc
-  - name: None attributes accessed
-    file: sast-policy-73.adoc
-  - name: Writing unvalidated input into JSON
-    file: sast-policy-82.adoc
-  - name: Path injection
-    file: sast-policy-86.adoc
-  - name: Dynamic code execution (vulnerable to injection attacks)
-    file: sast-policy-87.adoc
-  - name: HTTP response headers should not be vulnerable to injection attacks
-    file: sast-policy-88.adoc
-  - name: Cross-site scripting (XSS) exposure
-    file: sast-policy-89.adoc
-  - name: Improper Restriction of XML External Entity Reference
-    file: sast-policy-90.adoc
-  - name: Uncontrolled Resource Consumption
-    file: sast-policy-91.adoc
-  - name: Cleartext Transmission of Sensitive Information
-    file: sast-policy-93.adoc
-  - name: Improper Certificate Validation
-    file: sast-policy-94.adoc
-  - name: Insecure active debug code
-    file: sast-policy-96.adoc
-  - name: Improper access control
-    file: sast-policy-97.adoc
-  - name: Key Exchange without Entity Authentication
-    file: sast-policy-98.adoc
-  - name: Insecure temporary file
-    file: sast-policy-99.adoc
-  - name: SAST Python Policy Index
-    file: sast-python-policy-index.adoc
+# kind: chapter
+# name: SAST Policies
+# dir: sast-policies
+# topics:
+# - name: SAST Policies
+#   file: sast-policies.adoc
+# - name: Java policies
+#   dir: java-policies
+#   topics:
+#   - name: SAST Java Policy Index
+#     file: sast-java-policy-index.adoc
+#   - name: Improper neutralization of input during web page generation ('Cross-site
+#       Scripting')
+#     file: sast-policy-1.adoc
+#   - name: Cleartext Transmission of Sensitive Information
+#     file: sast-policy-102.adoc
+#   - name: Collapse of data into unsafe value
+#     file: sast-policy-103.adoc
+#   - name: Cross-Site Request Forgery (CSRF)
+#     file: sast-policy-104.adoc
+#   - name: Deserialization of untrusted data
+#     file: sast-policy-105.adoc
+#   - name: Deserialization of Untrusted Data
+#     file: sast-policy-106.adoc
+#   - name: External Control of System or Configuration Setting
+#     file: sast-policy-107.adoc
+#   - name: External control of system or configuration setting
+#     file: sast-policy-108.adoc
+#   - name: Improper authentication
+#     file: sast-policy-109.adoc
+#   - name: Improper certificate validation
+#     file: sast-policy-110.adoc
+#   - name: Improper certificate validation
+#     file: sast-policy-111.adoc
+#   - name: Improper control of generation of code ('Code Injection')
+#     file: sast-policy-112.adoc
+#   - name: Improper control of generation of code ('Code Injection')
+#     file: sast-policy-113.adoc
+#   - name: Improper Handling of Unicode Encoding
+#     file: sast-policy-114.adoc
+#   - name: Improper Input Validation
+#     file: sast-policy-115.adoc
+#   - name: Improper Input Validation
+#     file: sast-policy-116.adoc
+#   - name: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+#     file: sast-policy-117.adoc
+#   - name: Improper neutralization of CRLF sequences ('CRLF Injection')
+#     file: sast-policy-118.adoc
+#   - name: Improper neutralization of data within XPath expressions ('XPath Injection')
+#     file: sast-policy-119.adoc
+#   - name: Integrity of the data during transmission is not being verified
+#     file: sast-policy-12.adoc
+#   - name: Improper neutralization of CRLF sequences ('CRLF Injection')
+#     file: sast-policy-120.adoc
+#   - name: Improper neutralization of special elements used in a command
+#     file: sast-policy-121.adoc
+#   - name: Improper neutralization of special elements used in an expression language statement ('Expression Language Injection')
+#     file: sast-policy-122.adoc
+#   - name: Improper neutralization of special elements used in an OS command ('OS Command Injection')
+#     file: sast-policy-123.adoc
+#   - name: Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')
+#     file: sast-policy-124.adoc
+#   - name: Utilizing a class that isn't primitive in Java RMI could lead to a vulnerability associated with insecure deserialization.
+#     file: sast-policy-125.adoc
+#   - name: Improper privilege management
+#     file: sast-policy-126.adoc
+#   - name: Improper restriction of XML external entity reference ('XXE')
+#     file: sast-policy-127.adoc
+#   - name: Improper restriction of XML external entity reference ('XXE')
+#     file: sast-policy-128.adoc
+#   - name: Improper validation of certificate with host mismatch
+#     file: sast-policy-129.adoc
+#   - name: Unsafe custom MessageDigest is implemented
+#     file: sast-policy-13.adoc
+#   - name: Inadequate encryption strength
+#     file: sast-policy-130.adoc
+#   - name: Inadequate encryption strength
+#     file: sast-policy-131.adoc
+#   - name: Inadequate encryption strength
+#     file: sast-policy-132.adoc
+#   - name: 'Incorrect behavior order: validate before canonicalize'
+#     file: sast-policy-133.adoc
+#   - name: Incorrect permission assignment for critical resource
+#     file: sast-policy-134.adoc
+#   - name: Incorrect Permission Assignment for Critical Resource
+#     file: sast-policy-135.adoc
+#   - name: Incorrect type conversion or cast
+#     file: sast-policy-136.adoc
+#   - name: Information exposure through an error message
+#     file: sast-policy-137.adoc
+#   - name: Information exposure through an error message
+#     file: sast-policy-138.adoc
+#   - name: Missing authentication for critical function (database)
+#     file: sast-policy-139.adoc
+#   - name: Unsafe use of Cross-Origin Resource Sharing (CORS)
+#     file: sast-policy-14.adoc
+#   - name: Missing authentication for critical function (LDAP)
+#     file: sast-policy-140.adoc
+#   - name: Permissive Cross-domain Policy with Untrusted Domains
+#     file: sast-policy-141.adoc
+#   - name: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
+#     file: sast-policy-142.adoc
+#   - name: Sensitive Cookie in HTTPS Session Without 'Secure' Attribute
+#     file: sast-policy-143.adoc
+#   - name: Sensitive cookie without 'HttpOnly' flag
+#     file: sast-policy-144.adoc
+#   - name: Server-Side Request Forgery (SSRF)
+#     file: sast-policy-145.adoc
+#   - name: URL Redirection to Untrusted Site ('Open Redirect')
+#     file: sast-policy-147.adoc
+#   - name: Use of a broken or risky cryptographic algorithm
+#     file: sast-policy-148.adoc
+#   - name: Use of a broken or risky cryptographic algorithm (SHA1/MD5)
+#     file: sast-policy-149.adoc
+#   - name: Unsafe use of hazelcast symmetric encryption
+#     file: sast-policy-15.adoc
+#   - name: Use of externally-controlled format string
+#     file: sast-policy-150.adoc
+#   - name: Unencrypted payload with JWT
+#     file: sast-policy-151.adoc
+#   - name: Use of insufficiently random values
+#     file: sast-policy-155.adoc
+#   - name: Use of RSA algorithm without OAEP
+#     file: sast-policy-156.adoc
+#   - name: Cookie created without HttpOnly flag
+#     file: sast-policy-16.adoc
+#   - name: Permissive cross-domain policy with untrusted domains
+#     file: sast-policy-162.adoc
+#   - name: Improper neutralization of special elements in output used by a downstream component ('Injection')
+#     file: sast-policy-163.adoc
+#   - name: Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')
+#     file: sast-policy-164.adoc
+#   - name: Improper Neutralization of Special Elements in Data Query Logic
+#     file: sast-policy-165.adoc
+#   - name: Unsafe DES algorithm used
+#     file: sast-policy-17.adoc
+#   - name: Expression injection (OGNL)
+#     file: sast-policy-171.adoc
+#   - name: Improper neutralization of special elements used in an LDAP query ('LDAP Injection')
+#     file: sast-policy-172.adoc
+#   - name: Encryption keys with less than 128 bits
+#     file: sast-policy-18.adoc
+#   - name: Cookie created without Secure flag set
+#     file: sast-policy-19.adoc
+#   - name: Cookie stored for an extended period of time
+#     file: sast-policy-20.adoc
+#   - name: Cookie contains sensitive session info
+#     file: sast-policy-21.adoc
+#   - name: Trust Boundary is Violated
+#     file: sast-policy-22.adoc
+#   - name: Security of REST web service is not analyzed
+#     file: sast-policy-23.adoc
+#   - name: File Creation in Publicly Shared Directories
+#     file: sast-policy-24.adoc
+#   - name: CSRF is Disabled
+#     file: sast-policy-25.adoc
+#   - name: Authorization is not robust
+#     file: sast-policy-26.adoc
+#   - name: Pathname input not restricted
+#     file: sast-policy-43.adoc
+#   - name: File path not validated in file uploads
+#     file: sast-policy-44.adoc
+#   - name: Pathname not restricted in HTTP requests
+#     file: sast-policy-45.adoc
+#   - name: File path not validated for file writes
+#     file: sast-policy-46.adoc
+#   - name: Missing validation for paths when processing style sheets
+#     file: sast-policy-47.adoc
+#   - name: Unrestricted directory for pathname construction from HTTP requests
+#     file: sast-policy-48.adoc
+#   - name: Unrestricted pathnames from HTTP requests
+#     file: sast-policy-49.adoc
+#   - name: Improper neutralization of argument delimiters in a command ('Argument Injection')
+#     file: sast-policy-7.adoc
+#   - name: Files or directories accessible to external parties
+#     file: sast-policy-8.adoc
+#   - name: Improper neutralization of CRLF sequences in HTTP headers ('HTTP Response Splitting')
+#     file: sast-policy-9.adoc
+# - name: Javascript policies
+#   dir: javascript-policies
+#   topics:
+#   - name: SAST JavaScript Policy Index
+#     file: sast-javascript-policy-index.adoc
+#   - name: Insecure SSL Server Identity Verification Disabled
+#     file: sast-policy-101.adoc
+#   - name: Ensure Usage of JWT Algo
+#     file: sast-policy-146.adoc
+#   - name: Sensitive Data Logging
+#     file: sast-policy-153.adoc
+#   - name: Cross-Site Request Forgery (CSRF)
+#     file: sast-policy-157.adoc
+#   - name: Improper restriction of operations within the bounds of a memory buffer
+#     file: sast-policy-158.adoc
+#   - name: Incorrect regular expression
+#     file: sast-policy-159.adoc
+#   - name: Information Exposure Through an Error Message
+#     file: sast-policy-160.adoc
+#   - name: Observable timing discrepancy
+#     file: sast-policy-161.adoc
+#   - name: Escape markup is removed leading to risk for XSS
+#     file: sast-policy-27.adoc
+#   - name: CSRF is not used before `methodOverride`
+#     file: sast-policy-28.adoc
+#   - name: Calls to fs functions that take a non Literal value as the filename parameter
+#     file: sast-policy-29.adoc
+#   - name: Bracket object notation with user input
+#     file: sast-policy-30.adoc
+#   - name: Insecure use of crypto.pseudoRandomBytes
+#     file: sast-policy-31.adoc
+#   - name: Creating temp tile done with insecure permissions
+#     file: sast-policy-32.adoc
+#   - name: Encryption Keys are less than 16 bytes
+#     file: sast-policy-33.adoc
+#   - name: Hash used without salt
+#     file: sast-policy-34.adoc
+#   - name: Use of RSA Algorithm without Optimal Asymmetric Encryption Padding (OAEP)
+#     file: sast-policy-35.adoc
+#   - name: Superuser port is set
+#     file: sast-policy-36.adoc
+#   - name: Insecure use of weak hashing algorithms
+#     file: sast-policy-38.adoc
+#   - name: Use of insecure HTTP connections
+#     file: sast-policy-39.adoc
+#   - name: Use of insecure HTTP Connections with Axios
+#     file: sast-policy-40.adoc
+#   - name: Insecure use of `eval` with non-string parameters
+#     file: sast-policy-41.adoc
+#   - name: Insecure use of `new Buffer()`
+#     file: sast-policy-42.adoc
+#   - name: Insecure communication using postMessage and event listeners
+#     file: sast-policy-74.adoc
+#   - name: Encryption algorithm not using secure modes and padding
+#     file: sast-policy-75.adoc
+#   - name: Risk of Regular Expression Denial of Service (ReDoS)
+#     file: sast-policy-76.adoc
+#   - name: Weak SSL/TLS protocols
+#     file: sast-policy-77.adoc
+#   - name: Restrict Unnecessary Powerful Browser Features
+#     file: sast-policy-78.adoc
+#   - name: Prevent Public Network Access to Cloud Resources
+#     file: sast-policy-79.adoc
+#   - name: Enforce HTTPS Access for S3 Buckets
+#     file: sast-policy-80.adoc
+#   - name: Prevent OS Command Argument Injections
+#     file: sast-policy-81.adoc
+#   - name: Complex/formatted SQL query
+#     file: sast-policy-83.adoc
+#   - name: AngularJS misconfiguration dangerous protocol allowed
+#     file: sast-policy-84.adoc
+#   - name: AngularJS Misconfiguration Strict Contextual Escaping Disabled
+#     file: sast-policy-85.adoc
+#   - name: Detection of XSS vulnerability
+#     file: sast-policy-92.adoc
+#   - name: Cookie Security Overly Permissive Samesite Attribute
+#     file: sast-policy-95.adoc
+# - name: Python policies
+#   dir: python-policies
+#   topics:
+#   - name: Encryption keys below 2048 bit
+#     file: sast-policy-10.adoc
+#   - name: Improper Check or Handling of Exceptional Conditions
+#     file: sast-policy-100.adoc
+#   - name: Use of module setting superuser port
+#     file: sast-policy-11.adoc
+#   - name: Hardcoded passwords are being used
+#     file: sast-policy-152.adoc
+#   - name: Unsanitized path input from an HTTP parameter is being opened
+#     file: sast-policy-154.adoc
+#   - name: Improper Check or Handling of Exceptional Conditions
+#     file: sast-policy-166.adoc
+#   - name: Use of Insufficiently Random Values
+#     file: sast-policy-167.adoc
+#   - name: Improper Control of Generation of Code ('Code Injection')
+#     file: sast-policy-168.adoc
+#   - name: Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')
+#     file: sast-policy-169.adoc
+#   - name: Improper Neutralization of Wildcards or Matching Symbols
+#     file: sast-policy-170.adoc
+#   - name: Unsafe use of 'exec' command
+#     file: sast-policy-2.adoc
+#   - name: chmod sets a permissive mask on file
+#     file: sast-policy-3.adoc
+#   - name: Use of insecure IPMI-related modules
+#     file: sast-policy-37.adoc
+#   - name: Improper handling of checking for unusual or exceptional conditions
+#     file: sast-policy-4.adoc
+#   - name: Unsanitized input from data from a remote resource flows into os.system
+#     file: sast-policy-48.adoc
+#   - name: Publicly exposed servers
+#     file: sast-policy-5.adoc
+#   - name: XML Parsers exposed to XXE Vulnerabilities
+#     file: sast-policy-50.adoc
+#   - name: Request exposed to SQL injection
+#     file: sast-policy-51.adoc
+#   - name: User input not protected against NoSQL injection
+#     file: sast-policy-52.adoc
+#   - name: Not using HttpOnly flag when setting cookies
+#     file: sast-policy-53.adoc
+#   - name: JWTs are not properly verified before decoding
+#     file: sast-policy-54.adoc
+#   - name: Weak cryptographic algorithm used
+#     file: sast-policy-55.adoc
+#   - name: CSRF protections disabled
+#     file: sast-policy-56.adoc
+#   - name: Improper logger configuration
+#     file: sast-policy-57.adoc
+#   - name: Untrusted data unsafely deserialized
+#     file: sast-policy-58.adoc
+#   - name: Encryption algorithms used with an insecure mode or padding
+#     file: sast-policy-59.adoc
+#   - name: Use of hardcoded passwords in Python code
+#     file: sast-policy-6.adoc
+#   - name: HTML Autoescape Mechanism Should Not Be Globally Disabled
+#     file: sast-policy-60.adoc
+#   - name: LDAP Queries Should Not Be Vulnerable to Injection Attacks
+#     file: sast-policy-61.adoc
+#   - name: Logging Should Not Be Vulnerable to Injection Attacks
+#     file: sast-policy-62.adoc
+#   - name: Sending Emails is Security-Sensitive
+#     file: sast-policy-63.adoc
+#   - name: Server Hostnames Should not verified during SSL/TLS connections
+#     file: sast-policy-64.adoc
+#   - name: Inadequate Encryption Strength
+#     file: sast-policy-65.adoc
+#   - name: LDAP anonymous binds are used
+#     file: sast-policy-66.adoc
+#   - name: Weak SSL/TLS protocol used
+#     file: sast-policy-67.adoc
+#   - name: Weak SSL/TLS protocol used
+#     file: sast-policy-68.adoc
+#   - name: Files and directories are assigned loose permissions
+#     file: sast-policy-69.adoc
+#   - name: Improper Authorization in Handler for Custom URL Scheme
+#     file: sast-policy-70.adoc
+#   - name: Insecure use of no password or weak password when connecting to a database
+#     file: sast-policy-71.adoc
+#   - name: Hash functions used without an unpredictable salt
+#     file: sast-policy-72.adoc
+#   - name: None attributes accessed
+#     file: sast-policy-73.adoc
+#   - name: Writing unvalidated input into JSON
+#     file: sast-policy-82.adoc
+#   - name: Path injection
+#     file: sast-policy-86.adoc
+#   - name: Dynamic code execution (vulnerable to injection attacks)
+#     file: sast-policy-87.adoc
+#   - name: HTTP response headers should not be vulnerable to injection attacks
+#     file: sast-policy-88.adoc
+#   - name: Cross-site scripting (XSS) exposure
+#     file: sast-policy-89.adoc
+#   - name: Improper Restriction of XML External Entity Reference
+#     file: sast-policy-90.adoc
+#   - name: Uncontrolled Resource Consumption
+#     file: sast-policy-91.adoc
+#   - name: Cleartext Transmission of Sensitive Information
+#     file: sast-policy-93.adoc
+#   - name: Improper Certificate Validation
+#     file: sast-policy-94.adoc
+#   - name: Insecure active debug code
+#     file: sast-policy-96.adoc
+#   - name: Improper access control
+#     file: sast-policy-97.adoc
+#   - name: Key Exchange without Entity Authentication
+#     file: sast-policy-98.adoc
+#   - name: Insecure temporary file
+#     file: sast-policy-99.adoc
+#   - name: SAST Python Policy Index
+#     file: sast-python-policy-index.adoc


### PR DESCRIPTION
From the [Slack conversation](https://panw-global.slack.com/archives/C01Q2LR0LF6/p1699379284872359). Removing SAST policies from `book.yml`

Modified files:

- docs/en/enterprise-edition/policy-reference/book.yml

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
