### PR TITLE
Fix dir topics

### DIFF
--- a/docs/en/classic/appsec-admin-guide/book.yml
+++ b/docs/en/classic/appsec-admin-guide/book.yml
@@ -126,7 +126,7 @@ topics:
   - name: Integrate IDE
     dir: integrate-ide
     topics:
-    - name: IDE
+    - name: Integrate IDE
       file: integrate-ide.adoc
     - name: VS Code
       file: connect-vscode.adoc
@@ -207,7 +207,7 @@ topics:
 - name: Software Bill of Materials Generation
   dir: software-bill-of-materials-generation
   topics:
-  - name: Software Bill of Materials Generation (SBOM)
+  - name: Software Bill of Materials Generation
     file: software-bill-of-materials-generation.adoc
   - name: SBOM for CI/CD Security
     file: sbom.adoc

--- a/docs/en/compute-edition/22-12/admin-guide/book.yml
+++ b/docs/en/compute-edition/22-12/admin-guide/book.yml
@@ -153,7 +153,7 @@ topics:
 - name: Onboard Accounts for Agentless Scanning
   dir: onboard-accounts
   topics:
-  - name: Configure Agentless Scanning
+  - name: Onboard Accounts for Agentless Scanning
     file: onboard-accounts.adoc
   - name: Onboard AWS Accounts
     file: onboard-aws.adoc
@@ -283,7 +283,7 @@ topics:
 - name: Credentials Store
   dir: credentials-store
   topics:
-  - name: Credentials store
+  - name: Credentials Store
     file: credentials-store.adoc
   - name: AWS Credentials
     file: aws-credentials.adoc
@@ -339,7 +339,7 @@ topics:
 - name: Registry Scans
   dir: registry_scanning
   topics:
-  - name: Registry scanning
+  - name: Registry Scans
     file: registry_scanning.adoc
   - name: Configure Registry Scans
     file: configure_registry_scanning.adoc
@@ -734,10 +734,10 @@ topics:
   file: api.adoc
 ---
 kind: chapter
-name: How-to guides
+name: How-To Guides
 dir: howto
 topics:
-- name: Howto
+- name: How-To Guides
   file: howto.adoc
 - name: Configure an ECS load balancer
   file: configure_ecs_loadbalancer.adoc

--- a/docs/en/compute-edition/30/admin-guide/book.yml
+++ b/docs/en/compute-edition/30/admin-guide/book.yml
@@ -52,7 +52,7 @@ topics:
   - name: Deploy the Prisma Cloud Console On-Prem
     dir: deploy-console
     topics:
-      - name: Deploy the Prisma Cloud Console
+      - name: Deploy the Prisma Cloud Console On-Prem
         file: deploy-console.adoc
       - name: Prisma Cloud container images
         file: container-images.adoc
@@ -92,14 +92,14 @@ topics:
       - name: Deploy Container Defender
         dir: container
         topics:
-          - name: Install a Single Container Defender
+          - name: Deploy Container Defender
             file: container.adoc
           - name: Install a single Container Defender using the CLI
             file: single-defender-cli.adoc
       - name: Deploy Host Defender
         dir: host
         topics:
-          - name: Install a single Host Defender
+          - name: Deploy Host Defender
             file: host.adoc
           - name: Auto-defend Hosts
             file: auto-defend-host.adoc
@@ -129,13 +129,13 @@ topics:
       - name: Deploy Serverless Defender
         dir: serverless
         topics:
-          - name: Serverless Defender
+          - name: Deploy Serverless Defender
             file: serverless.adoc
           - name: Deploy Serverless Defender as a Lambda Layer
             file: install-serverless-defender-layer.adoc
           - name: Auto-defend serverless functions
             file: auto-defend-serverless.adoc
-      - name: Deploy App-embedded Defender
+      - name: Deploy App-Embedded Defender
         dir: app-embedded
         topics:
           - name: Deploy App-Embedded Defender
@@ -189,7 +189,7 @@ topics:
 - name: Onboard Accounts for Agentless Scanning
   dir: onboard-accounts
   topics:
-  - name: Configure Agentless Scanning
+  - name: Onboard Accounts for Agentless Scanning
     file: onboard-accounts.adoc
   - name: Onboard AWS Accounts
     file: onboard-aws.adoc
@@ -325,7 +325,7 @@ topics:
   - name: Credentials Store
     dir: credentials-store
     topics:
-      - name: Credentials store
+      - name: Credentials Store
         file: credentials-store.adoc
       - name: AWS Credentials
         file: aws-credentials.adoc
@@ -383,7 +383,7 @@ topics:
   - name: Registry Scans
     dir: registry-scanning
     topics:
-      - name: Registry scanning
+      - name: Registry Scans
         file: registry-scanning.adoc
       - name: Configure Registry Scans
         file: configure-registry-scanning.adoc
@@ -782,10 +782,10 @@ topics:
     file: api.adoc
 ---
 kind: chapter
-name: How-to guides
+name: How-To Guides
 dir: howto
 topics:
-  - name: Howto
+  - name: How-To Guides
     file: howto.adoc
   - name: Configure an ECS load balancer
     file: configure-ecs-loadbalancer.adoc

--- a/docs/en/compute-edition/31/admin-guide/book.yml
+++ b/docs/en/compute-edition/31/admin-guide/book.yml
@@ -52,7 +52,7 @@ topics:
   - name: Deploy the Prisma Cloud Console On-Prem
     dir: deploy-console
     topics:
-      - name: Deploy the Prisma Cloud Console
+      - name: Deploy the Prisma Cloud Console On-Prem
         file: deploy-console.adoc
       - name: Prisma Cloud container images
         file: container-images.adoc
@@ -92,14 +92,14 @@ topics:
       - name: Deploy Container Defender
         dir: container
         topics:
-          - name: Install a Single Container Defender
+          - name: Deploy Container Defender
             file: container.adoc
           - name: Install a single Container Defender using the CLI
             file: single-defender-cli.adoc
       - name: Deploy Host Defender
         dir: host
         topics:
-          - name: Install a single Host Defender
+          - name: Deploy Host Defender
             file: host.adoc
           - name: Auto-defend Hosts
             file: auto-defend-host.adoc
@@ -129,13 +129,13 @@ topics:
       - name: Deploy Serverless Defender
         dir: serverless
         topics:
-          - name: Serverless Defender
+          - name: Deploy Serverless Defender
             file: serverless.adoc
           - name: Deploy Serverless Defender as a Lambda Layer
             file: install-serverless-defender-layer.adoc
           - name: Auto-defend serverless functions
             file: auto-defend-serverless.adoc
-      - name: Deploy App-embedded Defender
+      - name: Deploy App-Embedded Defender
         dir: app-embedded
         topics:
           - name: Deploy App-Embedded Defender
@@ -189,7 +189,7 @@ topics:
 - name: Onboard Accounts for Agentless Scanning
   dir: onboard-accounts
   topics:
-  - name: Configure Agentless Scanning
+  - name: Onboard Accounts for Agentless Scanning
     file: onboard-accounts.adoc
   - name: Onboard AWS Accounts
     file: onboard-aws.adoc
@@ -325,7 +325,7 @@ topics:
   - name: Credentials Store
     dir: credentials-store
     topics:
-      - name: Credentials store
+      - name: Credentials Store
         file: credentials-store.adoc
       - name: AWS Credentials
         file: aws-credentials.adoc
@@ -381,7 +381,7 @@ topics:
   - name: Registry Scans
     dir: registry-scanning
     topics:
-      - name: Registry scanning
+      - name: Registry Scans
         file: registry-scanning.adoc
       - name: Configure Registry Scans
         file: configure-registry-scanning.adoc
@@ -778,10 +778,10 @@ topics:
     file: api.adoc
 ---
 kind: chapter
-name: How-to guides
+name: How-To Guides
 dir: howto
 topics:
-  - name: Howto
+  - name: How-To Guides
     file: howto.adoc
   - name: Configure an ECS load balancer
     file: configure-ecs-loadbalancer.adoc

--- a/docs/en/enterprise-edition/content-collections/book.yml
+++ b/docs/en/enterprise-edition/content-collections/book.yml
@@ -238,7 +238,7 @@ kind: chapter
 name: Reports
 dir: reports
 topics:
-  - name: Prisma Cloud Reports
+  - name: Reports
     file: reports.adoc
   - name: Get Started with Reports
     file: prisma-cloud-reports.adoc  
@@ -577,7 +577,7 @@ kind: chapter
 name: Runtime Security
 dir: runtime-security
 topics:
-  - name: Runtime Security at a Glance
+  - name: Runtime Security
     file: runtime-security.adoc
   - name: Runtime Security Architecture
     file: rs-architecture.adoc
@@ -661,7 +661,7 @@ topics:
                 file: lambda-layer.adoc
               - name: Auto-defend serverless functions
                 file: auto-defend-serverless.adoc
-          - name: Deploy App-embedded Defender
+          - name: Deploy App-Embedded Defender
             dir: app-embedded
             topics:
               - name: Deploy App-Embedded Defender
@@ -941,7 +941,7 @@ topics:
     - name: Enforce Compliance Checks
       dir: operations
       topics:
-        - name: Enforce Compliance Check
+        - name: Enforce Compliance Checks
           file: operations.adoc
         - name: Manage Compliance
           file: manage-compliance.adoc
@@ -1111,7 +1111,7 @@ topics:
       - name: Secrets Stores
         dir: secrets-stores
         topics:
-          - name: Secrets stores
+          - name: Secrets Stores
             file: secrets-stores.adoc
           - name: AWS Secrets Manager
             file: aws-secrets-manager.adoc

--- a/docs/en/enterprise-edition/policy-reference/book.yml
+++ b/docs/en/enterprise-edition/policy-reference/book.yml
@@ -18,7 +18,7 @@ kind: chapter
 name: Get Started with Prisma Cloud Code Security Policies
 dir: get-started-code-sec-policies
 topics:
-- name: Prisma Cloud Code Security Policy Reference
+- name: Get Started with Prisma Cloud Code Security Policies
   file: get-started-code-sec-policies.adoc
 ---
 kind: chapter


### PR DESCRIPTION
Fix all book.yml files so that dir topics are properly named.

Clicking on some dirs (with the expand/collapse control) in the left nav causes some load weirdness that confuses users due to issues in the underlying book.yml

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=ian-fix-dir-topics2
