### PR TITLE
notification templates are changed from alerts to settings.adoc

### DIFF
--- a/docs/en/enterprise-edition/content-collections/alerts/send-prisma-cloud-alert-notifications-to-third-party-tools.adoc
+++ b/docs/en/enterprise-edition/content-collections/alerts/send-prisma-cloud-alert-notifications-to-third-party-tools.adoc
@@ -85,7 +85,7 @@ All email notifications from Prisma Cloud include the domain name to support Dom
 +
 Prisma Cloud provides a default email template for your convenience, and you can customize the lead-in message within the body of the email using the rich-text editor.
 
-.. Select *Alerts > Notification Templates" and *Add Notification Template*
+.. Select *Settings > Notification Templates" and *Add Notification Template*
 
 .. Select the *Email* Notification template from the list.
 


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
