### PR TITLE
Resorted Sast Policies jb

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/sast-policies/java-policies/sast-java-policy-index.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/java-policies/sast-java-policy-index.adoc
@@ -33,10 +33,6 @@
 |CKV3_SAST_114
 |HIGH
 
-|xref:sast-policy-116.adoc[Improper Input Validation]
-|CKV3_SAST_116
-|HIGH
-
 |xref:sast-policy-117.adoc[Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')]
 |CKV3_SAST_117
 |HIGH
@@ -89,16 +85,8 @@
 |CKV3_SAST_47
 |HIGH
 
-|xref:sast-policy-141.adoc[Permissive Cross-domain Policy with Untrusted Domains]
-|CKV3_SAST_141
-|HIGH
-
 |xref:sast-policy-145.adoc[Server-Side Request Forgery (SSRF)]
 |CKV3_SAST_145
-|HIGH
-
-|xref:sast-policy-49.adoc[Unrestricted pathnames from HTTP requests]
-|CKV3_SAST_49
 |HIGH
 
 |xref:sast-policy-147.adoc[URL Redirection to Untrusted Site ('Open Redirect')]
@@ -141,10 +129,6 @@
 |CKV3_SAST_105
 |MEDIUM
 
-|xref:sast-policy-106.adoc[Deserialization of Untrusted Data]
-|CKV3_SAST_106
-|MEDIUM
-
 |xref:sast-policy-18.adoc[Encryption keys with less than 128 bits]
 |CKV3_SAST_18
 |MEDIUM
@@ -175,14 +159,6 @@
 
 |xref:sast-policy-111.adoc[Improper certificate validation]
 |CKV3_SAST_111
-|MEDIUM
-
-|xref:sast-policy-115.adoc[Improper Input Validation]
-|CKV3_SAST_115
-|MEDIUM
-
-|xref:sast-policy-9.adoc[Improper neutralization of CRLF sequences in HTTP headers ('HTTP Response Splitting')]
-|CKV3_SAST_9
 |MEDIUM
 
 |xref:sast-policy-123.adoc[Improper neutralization of special elements used in an OS command ('OS Command Injection')]
@@ -221,16 +197,8 @@
 |CKV3_SAST_134
 |MEDIUM
 
-|xref:sast-policy-135.adoc[Incorrect Permission Assignment for Critical Resource]
-|CKV3_SAST_135
-|MEDIUM
-
 |xref:sast-policy-136.adoc[Incorrect type conversion or cast]
 |CKV3_SAST_136
-|MEDIUM
-
-|xref:sast-policy-137.adoc[Information exposure through an error message]
-|CKV3_SAST_137
 |MEDIUM
 
 |xref:sast-policy-138.adoc[Information exposure through an error message]
@@ -265,10 +233,6 @@
 |CKV3_SAST_142
 |MEDIUM
 
-|xref:sast-policy-143.adoc[Sensitive Cookie in HTTPS Session Without 'Secure' Attribute]
-|CKV3_SAST_143
-|MEDIUM
-
 |xref:sast-policy-144.adoc[Sensitive cookie without 'HttpOnly' flag]
 |CKV3_SAST_144
 |MEDIUM
@@ -287,10 +251,6 @@
 
 |xref:sast-policy-17.adoc[Unsafe DES algorithm used]
 |CKV3_SAST_17
-|MEDIUM
-
-|xref:sast-policy-14.adoc[Unsafe use of Cross-Origin Resource Sharing (CORS)]
-|CKV3_SAST_14
 |MEDIUM
 
 |xref:sast-policy-149.adoc[Use of a broken or risky cryptographic algorithm (SHA1/MD5)]
@@ -321,21 +281,8 @@
 |CKV3_SAST_44
 |LOW
 
-|xref:sast-policy-164.adoc[Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')]
-|CKV3_SAST_164
-|LOW
-
-|xref:sast-policy-1.adoc[Improper neutralization of input during web page generation ('Cross-site Scripting')]
-|CKV3_SAST_1
-|LOW
-
-
 |xref:sast-policy-15.adoc[Unsafe use of hazelcast symmetric encryption]
 |CKV3_SAST_15
-|LOW
-
-|xref:sast-policy-22.adoc[Trust Boundary is Violated]
-|CKV3_SAST_22
 |LOW
 
 |===

--- a/docs/en/enterprise-edition/policy-reference/sast-policies/java-policies/sast-java-policy-index.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/java-policies/sast-java-policy-index.adoc
@@ -5,109 +5,125 @@
 |===
 |Policy|Checkov ID| Severity
 
-|xref:sast-policy-1.adoc[Improper neutralization of input during web page generation ('Cross-site Scripting')]
-|CKV3_SAST_1
-|LOW
+|xref:sast-policy-21.adoc[Cookie contains sensitive session info]
+|CKV3_SAST_21
+|HIGH
 
-|xref:sast-policy-7.adoc[Improper neutralization of argument delimiters in a command ('Argument Injection')]
-|CKV3_SAST_7
+|xref:sast-policy-107.adoc[External Control of System or Configuration Setting]
+|CKV3_SAST_107
+|HIGH
+
+|xref:sast-policy-171.adoc[Expression injection (OGNL)]
+|CKV3_SAST_171
 |HIGH
 
 |xref:sast-policy-8.adoc[Files or directories accessible to external parties]
 |CKV3_SAST_8
 |HIGH
 
-|xref:sast-policy-9.adoc[Improper neutralization of CRLF sequences in HTTP headers ('HTTP Response Splitting')]
-|CKV3_SAST_9
-|MEDIUM
-
-|xref:sast-policy-12.adoc[Integrity of the data during transmission is not being verified]
-|CKV3_SAST_12
-|MEDIUM
-
-|xref:sast-policy-13.adoc[Unsafe custom MessageDigest is implemented]
-|CKV3_SAST_13
-|MEDIUM
-
-|xref:sast-policy-14.adoc[Unsafe use of Cross-Origin Resource Sharing (CORS)]
-|CKV3_SAST_14
-|MEDIUM
-
-|xref:sast-policy-15.adoc[Unsafe use of hazelcast symmetric encryption]
-|CKV3_SAST_15
-|LOW
-
-|xref:sast-policy-16.adoc[Cookie created without HttpOnly flag]
-|CKV3_SAST_16
-|LOW
-
-|xref:sast-policy-17.adoc[Unsafe DES algorithm used]
-|CKV3_SAST_17
-|MEDIUM
-
-|xref:sast-policy-18.adoc[Encryption keys with less than 128 bits]
-|CKV3_SAST_18
-|MEDIUM
-
-|xref:sast-policy-19.adoc[Cookie created without Secure flag set]
-|CKV3_SAST_19
-|LOW
-
-|xref:sast-policy-20.adoc[Cookie stored for an extended period of time]
-|CKV3_SAST_20
-|MEDIUM
-
-|xref:sast-policy-21.adoc[Cookie contains sensitive session info]
-|CKV3_SAST_21
+|xref:sast-policy-112.adoc[Improper control of generation of code ('Code Injection')]
+|CKV3_SAST_112
 |HIGH
 
-|xref:sast-policy-22.adoc[Trust Boundary is Violated]
-|CKV3_SAST_22
-|LOW
+|xref:sast-policy-113.adoc[Improper control of generation of code ('Code Injection')]
+|CKV3_SAST_113
+|HIGH
 
-|xref:sast-policy-23.adoc[Security of REST web service is not analyzed]
-|CKV3_SAST_23
-|MEDIUM
+|xref:sast-policy-114.adoc[Improper Handling of Unicode Encoding]
+|CKV3_SAST_114
+|HIGH
 
-|xref:sast-policy-24.adoc[File Creation in Publicly Shared Directories]
-|CKV3_SAST_24
-|MEDIUM
+|xref:sast-policy-116.adoc[Improper Input Validation]
+|CKV3_SAST_116
+|HIGH
 
-|xref:sast-policy-25.adoc[CSRF is Disabled]
-|CKV3_SAST_25
-|MEDIUM
+|xref:sast-policy-117.adoc[Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')]
+|CKV3_SAST_117
+|HIGH
 
-|xref:sast-policy-26.adoc[Authorization is not robust]
-|CKV3_SAST_26
-|MEDIUM
+|xref:sast-policy-7.adoc[Improper neutralization of argument delimiters in a command ('Argument Injection')]
+|CKV3_SAST_7
+|HIGH
 
-|xref:sast-policy-43.adoc[Pathname input not restricted]
-|CKV3_SAST_43
-|MEDIUM
+|xref:sast-policy-120.adoc[Improper neutralization of CRLF sequences ('CRLF Injection')]
+|CKV3_SAST_120
+|HIGH
 
-|xref:sast-policy-44.adoc[File path not validated in file uploads]
-|CKV3_SAST_44
-|LOW
+|xref:sast-policy-118.adoc[Improper neutralization of CRLF sequences ('CRLF Injection')]
+|CKV3_SAST_118
+|HIGH
 
-|xref:sast-policy-45.adoc[Pathname not restricted in HTTP requests]
-|CKV3_SAST_45
-|MEDIUM
+|xref:sast-policy-119.adoc[Improper neutralization of data within XPath expressions ('XPath Injection')]
+|CKV3_SAST_119
+|HIGH
 
-|xref:sast-policy-46.adoc[File path not validated for file writes]
-|CKV3_SAST_46
-|MEDIUM
+|xref:sast-policy-172.adoc[Improper neutralization of special elements used in an LDAP query ('LDAP Injection')]
+|CKV3_SAST_172
+|HIGH
+
+|xref:sast-policy-121.adoc[Improper neutralization of special elements used in a command]
+|CKV3_SAST_121
+|HIGH
+
+|xref:sast-policy-122.adoc[Improper neutralization of special elements used in an expression language statement ('Expression Language Injection')]
+|CKV3_SAST_122
+|HIGH
+
+|xref:sast-policy-124.adoc[Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')]
+|CKV3_SAST_124
+|HIGH
+
+|xref:sast-policy-127.adoc[Improper restriction of XML external entity reference ('XXE')]
+|CKV3_SAST_127
+|HIGH
+
+|xref:sast-policy-128.adoc[Improper restriction of XML external entity reference ('XXE')]
+|CKV3_SAST_128
+|HIGH
+
+|xref:sast-policy-129.adoc[Improper validation of certificate with host mismatch]
+|CKV3_SAST_129
+|HIGH
 
 |xref:sast-policy-47.adoc[Missing validation for paths when processing style sheets]
 |CKV3_SAST_47
 |HIGH
 
-|xref:sast-policy-48.adoc[Unrestricted directory for pathname construction from HTTP requests]
-|CKV3_SAST_48
-|MEDIUM
+|xref:sast-policy-141.adoc[Permissive Cross-domain Policy with Untrusted Domains]
+|CKV3_SAST_141
+|HIGH
+
+|xref:sast-policy-145.adoc[Server-Side Request Forgery (SSRF)]
+|CKV3_SAST_145
+|HIGH
 
 |xref:sast-policy-49.adoc[Unrestricted pathnames from HTTP requests]
 |CKV3_SAST_49
 |HIGH
+
+|xref:sast-policy-147.adoc[URL Redirection to Untrusted Site ('Open Redirect')]
+|CKV3_SAST_147
+|HIGH
+
+|xref:sast-policy-148.adoc[Use of a broken or risky cryptographic algorithm]
+|CKV3_SAST_148
+|HIGH
+
+|xref:sast-policy-150.adoc[Use of externally-controlled format string]
+|CKV3_SAST_150
+|HIGH
+
+|xref:sast-policy-26.adoc[Authorization is not robust]
+|CKV3_SAST_26
+|MEDIUM
+
+|xref:sast-policy-20.adoc[Cookie stored for an extended period of time]
+|CKV3_SAST_20
+|MEDIUM
+
+|xref:sast-policy-25.adoc[CSRF is Disabled]
+|CKV3_SAST_25
+|MEDIUM
 
 |xref:sast-policy-102.adoc[Cleartext Transmission of Sensitive Information]
 |CKV3_SAST_102
@@ -129,12 +145,24 @@
 |CKV3_SAST_106
 |MEDIUM
 
-|xref:sast-policy-107.adoc[External Control of System or Configuration Setting]
-|CKV3_SAST_107
-|HIGH
+|xref:sast-policy-18.adoc[Encryption keys with less than 128 bits]
+|CKV3_SAST_18
+|MEDIUM
 
 |xref:sast-policy-108.adoc[External control of system or configuration setting]
 |CKV3_SAST_108
+|MEDIUM
+
+|xref:sast-policy-24.adoc[File Creation in Publicly Shared Directories]
+|CKV3_SAST_24
+|MEDIUM
+
+|xref:sast-policy-46.adoc[File path not validated for file writes]
+|CKV3_SAST_46
+|MEDIUM
+
+|xref:sast-policy-12.adoc[Integrity of the data during transmission is not being verified]
+|CKV3_SAST_12
 |MEDIUM
 
 |xref:sast-policy-109.adoc[Improper authentication]
@@ -149,80 +177,32 @@
 |CKV3_SAST_111
 |MEDIUM
 
-|xref:sast-policy-112.adoc[Improper control of generation of code ('Code Injection')]
-|CKV3_SAST_112
-|HIGH
-
-|xref:sast-policy-113.adoc[Improper control of generation of code ('Code Injection')]
-|CKV3_SAST_113
-|HIGH
-
-|xref:sast-policy-114.adoc[Improper Handling of Unicode Encoding]
-|CKV3_SAST_114
-|HIGH
-
 |xref:sast-policy-115.adoc[Improper Input Validation]
 |CKV3_SAST_115
 |MEDIUM
 
-|xref:sast-policy-116.adoc[Improper Input Validation]
-|CKV3_SAST_116
-|HIGH
-
-|xref:sast-policy-117.adoc[Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')]
-|CKV3_SAST_117
-|HIGH
-
-|xref:sast-policy-118.adoc[Improper neutralization of CRLF sequences ('CRLF Injection')]
-|CKV3_SAST_118
-|HIGH
-
-|xref:sast-policy-119.adoc[Improper neutralization of data within XPath expressions ('XPath Injection')]
-|CKV3_SAST_119
-|HIGH
-
-|xref:sast-policy-120.adoc[Improper neutralization of CRLF sequences ('CRLF Injection')]
-|CKV3_SAST_120
-|HIGH
-
-|xref:sast-policy-121.adoc[Improper neutralization of special elements used in a command]
-|CKV3_SAST_121
-|HIGH
-
-|xref:sast-policy-122.adoc[Improper neutralization of special elements used in an expression language statement ('Expression Language Injection')]
-|CKV3_SAST_122
-|HIGH
+|xref:sast-policy-9.adoc[Improper neutralization of CRLF sequences in HTTP headers ('HTTP Response Splitting')]
+|CKV3_SAST_9
+|MEDIUM
 
 |xref:sast-policy-123.adoc[Improper neutralization of special elements used in an OS command ('OS Command Injection')]
 |CKV3_SAST_123
 |MEDIUM
 
-|xref:sast-policy-124.adoc[Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')]
-|CKV3_SAST_124
-|HIGH
+|xref:sast-policy-130.adoc[Inadequate encryption strength]
+|CKV3_SAST_130
+|MEDIUM
 
-|xref:sast-policy-125.adoc[Utilizing a class that isn't primitive in Java RMI could lead to a vulnerability associated with insecure deserialization.]
-|CKV3_SAST_125
+|xref:sast-policy-165.adoc[Improper Neutralization of Special Elements in Data Query Logic]
+|CKV3_SAST_165
+|MEDIUM
+
+|xref:sast-policy-163.adoc[Improper neutralization of special elements in output used by a downstream component ('Injection')]
+|CKV3_SAST_163
 |MEDIUM
 
 |xref:sast-policy-126.adoc[Improper privilege management]
 |CKV3_SAST_126
-|MEDIUM
-
-|xref:sast-policy-127.adoc[Improper restriction of XML external entity reference ('XXE')]
-|CKV3_SAST_127
-|HIGH
-
-|xref:sast-policy-128.adoc[Improper restriction of XML external entity reference ('XXE')]
-|CKV3_SAST_128
-|HIGH
-
-|xref:sast-policy-129.adoc[Improper validation of certificate with host mismatch]
-|CKV3_SAST_129
-|HIGH
-
-|xref:sast-policy-130.adoc[Inadequate encryption strength]
-|CKV3_SAST_130
 |MEDIUM
 
 |xref:sast-policy-131.adoc[Inadequate encryption strength]
@@ -265,9 +245,21 @@
 |CKV3_SAST_140
 |MEDIUM
 
-|xref:sast-policy-141.adoc[Permissive Cross-domain Policy with Untrusted Domains]
-|CKV3_SAST_141
-|HIGH
+|xref:sast-policy-43.adoc[Pathname input not restricted]
+|CKV3_SAST_43
+|MEDIUM
+
+|xref:sast-policy-45.adoc[Pathname not restricted in HTTP requests]
+|CKV3_SAST_45
+|MEDIUM
+
+|xref:sast-policy-162.adoc[Permissive cross-domain policy with untrusted domains]
+|CKV3_SAST_162
+|MEDIUM
+
+|xref:sast-policy-23.adoc[Security of REST web service is not analyzed]
+|CKV3_SAST_23
+|MEDIUM
 
 |xref:sast-policy-142.adoc[Sensitive Cookie in HTTPS Session Without 'Secure' Attribute]
 |CKV3_SAST_142
@@ -281,28 +273,28 @@
 |CKV3_SAST_144
 |MEDIUM
 
-|xref:sast-policy-145.adoc[Server-Side Request Forgery (SSRF)]
-|CKV3_SAST_145
-|HIGH
+|xref:sast-policy-151.adoc[Unencrypted payload with JWT]
+|CKV3_SAST_151
+|MEDIUM
 
-|xref:sast-policy-147.adoc[URL Redirection to Untrusted Site ('Open Redirect')]
-|CKV3_SAST_147
-|HIGH
+|xref:sast-policy-48.adoc[Unrestricted directory for pathname construction from HTTP requests]
+|CKV3_SAST_48
+|MEDIUM
 
-|xref:sast-policy-148.adoc[Use of a broken or risky cryptographic algorithm]
-|CKV3_SAST_148
-|HIGH
+|xref:sast-policy-13.adoc[Unsafe custom MessageDigest is implemented]
+|CKV3_SAST_13
+|MEDIUM
+
+|xref:sast-policy-17.adoc[Unsafe DES algorithm used]
+|CKV3_SAST_17
+|MEDIUM
+
+|xref:sast-policy-14.adoc[Unsafe use of Cross-Origin Resource Sharing (CORS)]
+|CKV3_SAST_14
+|MEDIUM
 
 |xref:sast-policy-149.adoc[Use of a broken or risky cryptographic algorithm (SHA1/MD5)]
 |CKV3_SAST_149
-|MEDIUM
-
-|xref:sast-policy-150.adoc[Use of externally-controlled format string]
-|CKV3_SAST_150
-|HIGH
-
-|xref:sast-policy-151.adoc[Unencrypted payload with JWT]
-|CKV3_SAST_151
 |MEDIUM
 
 |xref:sast-policy-155.adoc[Use of insufficiently random values]
@@ -313,28 +305,37 @@
 |CKV3_SAST_156
 |MEDIUM
 
-|xref:sast-policy-162.adoc[Permissive cross-domain policy with untrusted domains]
-|CKV3_SAST_162
+|xref:sast-policy-125.adoc[Utilizing a class that isn't primitive in Java RMI could lead to a vulnerability associated with insecure deserialization.]
+|CKV3_SAST_125
 |MEDIUM
 
-|xref:sast-policy-163.adoc[Improper neutralization of special elements in output used by a downstream component ('Injection')]
-|CKV3_SAST_163
-|MEDIUM
+|xref:sast-policy-16.adoc[Cookie created without HttpOnly flag]
+|CKV3_SAST_16
+|LOW
+
+|xref:sast-policy-19.adoc[Cookie created without Secure flag set]
+|CKV3_SAST_19
+|LOW
+
+|xref:sast-policy-44.adoc[File path not validated in file uploads]
+|CKV3_SAST_44
+|LOW
 
 |xref:sast-policy-164.adoc[Improper Neutralization of Input During Web Page Generation ('Cross-site Scripting')]
 |CKV3_SAST_164
 |LOW
 
-|xref:sast-policy-165.adoc[Improper Neutralization of Special Elements in Data Query Logic]
-|CKV3_SAST_165
-|MEDIUM
+|xref:sast-policy-1.adoc[Improper neutralization of input during web page generation ('Cross-site Scripting')]
+|CKV3_SAST_1
+|LOW
 
-|xref:sast-policy-171.adoc[Expression injection (OGNL)]
-|CKV3_SAST_171
-|HIGH
 
-|xref:sast-policy-172.adoc[Improper neutralization of special elements used in an LDAP query ('LDAP Injection')]
-|CKV3_SAST_172
-|HIGH
+|xref:sast-policy-15.adoc[Unsafe use of hazelcast symmetric encryption]
+|CKV3_SAST_15
+|LOW
+
+|xref:sast-policy-22.adoc[Trust Boundary is Violated]
+|CKV3_SAST_22
+|LOW
 
 |===

--- a/docs/en/enterprise-edition/policy-reference/sast-policies/javascript-policies/sast-javascript-policy-index.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/javascript-policies/sast-javascript-policy-index.adoc
@@ -5,13 +5,29 @@
 |===
 |Policy|Checkov ID| Severity
 
-|xref:sast-policy-27.adoc[Escape markup is removed leading to risk for XSS]
-|CKV3_SAST_27
-|LOW
+|xref:sast-policy-76.adoc[Risk of Regular Expression Denial of Service (ReDoS)]
+|CKV3_SAST_76
+|HIGH
 
-|xref:sast-policy-28.adoc[CSRF is not used before `methodOverride`]
-|CKV3_SAST_28
-|LOW
+|xref:sast-policy-32.adoc[Creating temp tile done with insecure permissions]
+|CKV3_SAST_32
+|HIGH
+
+|xref:sast-policy-75.adoc[Encryption algorithm not using secure modes and padding]
+|CKV3_SAST_75
+|HIGH
+
+|xref:sast-policy-38.adoc[Insecure use of weak hashing algorithms]
+|CKV3_SAST_38
+|HIGH
+
+|xref:sast-policy-174.adoc[Relative Path Traversal]
+|CKV3_SAST_174
+|HIGH
+
+|xref:sast-policy-35.adoc[Use of RSA Algorithm without Optimal Asymmetric Encryption Padding (OAEP)]
+|CKV3_SAST_35
+|HIGH
 
 |xref:sast-policy-29.adoc[Calls to fs functions that take a non Literal value as the filename parameter]
 |CKV3_SAST_29
@@ -25,10 +41,6 @@
 |CKV3_SAST_31
 |MEDIUM
 
-|xref:sast-policy-32.adoc[Creating temp tile done with insecure permissions]
-|CKV3_SAST_32
-|HIGH
-
 |xref:sast-policy-33.adoc[Encryption Keys are less than 16 bytes]
 |CKV3_SAST_33
 |MEDIUM
@@ -37,45 +49,21 @@
 |CKV3_SAST_34
 |MEDIUM
 
-|xref:sast-policy-35.adoc[Use of RSA Algorithm without Optimal Asymmetric Encryption Padding (OAEP)]
-|CKV3_SAST_35
-|HIGH
-
 |xref:sast-policy-36.adoc[Superuser port is set]
 |CKV3_SAST_36
 |MEDIUM
-
-|xref:sast-policy-38.adoc[Insecure use of weak hashing algorithms]
-|CKV3_SAST_38
-|HIGH
 
 |xref:sast-policy-39.adoc[Use of insecure HTTP connections]
 |CKV3_SAST_39
 |MEDIUM
 
-|xref:sast-policy-40.adoc[Use of insecure HTTP Connections with Axios]
-|CKV3_SAST_40
-|LOW
-
 |xref:sast-policy-41.adoc[Insecure use of `eval` with non-string parameters]
 |CKV3_SAST_41
 |MEDIUM
 
-|xref:sast-policy-42.adoc[Insecure use of `new Buffer()`]
-|CKV3_SAST_42
-|LOW
-
 |xref:sast-policy-74.adoc[Insecure communication using postMessage and event listeners]
 |CKV3_SAST_74
 |MEDIUM
-
-|xref:sast-policy-75.adoc[Encryption algorithm not using secure modes and padding]
-|CKV3_SAST_75
-|HIGH
-
-|xref:sast-policy-76.adoc[Risk of Regular Expression Denial of Service (ReDoS)]
-|CKV3_SAST_76
-|HIGH
 
 |xref:sast-policy-77.adoc[Weak SSL/TLS protocols]
 |CKV3_SAST_77
@@ -149,10 +137,6 @@
 |CKV3_SAST_161
 |MEDIUM
 
-|xref:sast-policy-174.adoc[Relative Path Traversal]
-|CKV3_SAST_174
-|HIGH
-
 |xref:sast-policy-176.adoc[Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)]
 |CKV3_SAST_176
 |MEDIUM
@@ -164,6 +148,22 @@
 |xref:sast-policy-178.adoc[Improper Neutralization of Special Elements used in an SQL Command ('SQL Injection')]
 |CKV3_SAST_178
 |MEDIUM
+
+|xref:sast-policy-28.adoc[CSRF is not used before `methodOverride`]
+|CKV3_SAST_28
+|LOW
+
+|xref:sast-policy-27.adoc[Escape markup is removed leading to risk for XSS]
+|CKV3_SAST_27
+|LOW
+
+|xref:sast-policy-42.adoc[Insecure use of `new Buffer()`]
+|CKV3_SAST_42
+|LOW
+
+|xref:sast-policy-40.adoc[Use of insecure HTTP Connections with Axios]
+|CKV3_SAST_40
+|LOW
 
 
 |===

--- a/docs/en/enterprise-edition/policy-reference/sast-policies/javascript-policies/sast-javascript-policy-index.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/javascript-policies/sast-javascript-policy-index.adoc
@@ -37,10 +37,6 @@
 |CKV3_SAST_85
 |MEDIUM
 
-|xref:sast-policy-30.adoc[Bracket object notation with user input]
-|CKV3_SAST_30
-|MEDIUM
-
 |xref:sast-policy-29.adoc[Calls to fs functions that take a non Literal value as the filename parameter]
 |CKV3_SAST_29
 |MEDIUM
@@ -143,10 +139,6 @@
 
 |xref:sast-policy-84.adoc[AngularJS misconfiguration dangerous protocol allowed]
 |CKV3_SAST_84
-|LOW
-
-|xref:sast-policy-28.adoc[CSRF is not used before `methodOverride`]
-|CKV3_SAST_28
 |LOW
 
 |xref:sast-policy-92.adoc[Detection of XSS vulnerability]

--- a/docs/en/enterprise-edition/policy-reference/sast-policies/javascript-policies/sast-javascript-policy-index.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/javascript-policies/sast-javascript-policy-index.adoc
@@ -5,8 +5,8 @@
 |===
 |Policy|Checkov ID| Severity
 
-|xref:sast-policy-76.adoc[Risk of Regular Expression Denial of Service (ReDoS)]
-|CKV3_SAST_76
+|xref:sast-policy-83.adoc[Complex/formatted SQL query]
+|CKV3_SAST_83
 |HIGH
 
 |xref:sast-policy-32.adoc[Creating temp tile done with insecure permissions]
@@ -25,116 +25,56 @@
 |CKV3_SAST_174
 |HIGH
 
+|xref:sast-policy-76.adoc[Risk of Regular Expression Denial of Service (ReDoS)]
+|CKV3_SAST_76
+|HIGH
+
 |xref:sast-policy-35.adoc[Use of RSA Algorithm without Optimal Asymmetric Encryption Padding (OAEP)]
 |CKV3_SAST_35
 |HIGH
 
-|xref:sast-policy-29.adoc[Calls to fs functions that take a non Literal value as the filename parameter]
-|CKV3_SAST_29
+|xref:sast-policy-85.adoc[AngularJS Misconfiguration Strict Contextual Escaping Disabled]
+|CKV3_SAST_85
 |MEDIUM
 
 |xref:sast-policy-30.adoc[Bracket object notation with user input]
 |CKV3_SAST_30
 |MEDIUM
 
-|xref:sast-policy-31.adoc[Insecure use of crypto.pseudoRandomBytes]
-|CKV3_SAST_31
+|xref:sast-policy-29.adoc[Calls to fs functions that take a non Literal value as the filename parameter]
+|CKV3_SAST_29
 |MEDIUM
-
-|xref:sast-policy-33.adoc[Encryption Keys are less than 16 bytes]
-|CKV3_SAST_33
-|MEDIUM
-
-|xref:sast-policy-34.adoc[Hash used without salt]
-|CKV3_SAST_34
-|MEDIUM
-
-|xref:sast-policy-36.adoc[Superuser port is set]
-|CKV3_SAST_36
-|MEDIUM
-
-|xref:sast-policy-39.adoc[Use of insecure HTTP connections]
-|CKV3_SAST_39
-|MEDIUM
-
-|xref:sast-policy-41.adoc[Insecure use of `eval` with non-string parameters]
-|CKV3_SAST_41
-|MEDIUM
-
-|xref:sast-policy-74.adoc[Insecure communication using postMessage and event listeners]
-|CKV3_SAST_74
-|MEDIUM
-
-|xref:sast-policy-77.adoc[Weak SSL/TLS protocols]
-|CKV3_SAST_77
-|MEDIUM
-
-|xref:sast-policy-78.adoc[Restrict Unnecessary Powerful Browser Features]
-|CKV3_SAST_78
-|MEDIUM
-
-|xref:sast-policy-79.adoc[Prevent Public Network Access to Cloud Resources]
-|CKV3_SAST_79
-|MEDIUM
-
-|xref:sast-policy-80.adoc[Enforce HTTPS Access for S3 Buckets]
-|CKV3_SAST_80
-|MEDIUM
-
-|xref:sast-policy-81.adoc[Prevent OS Command Argument Injections]
-|CKV3_SAST_81
-|MEDIUM
-
-|xref:sast-policy-83.adoc[Complex/formatted SQL query]
-|CKV3_SAST_83
-|HIGH
-
-|xref:sast-policy-84.adoc[AngularJS misconfiguration dangerous protocol allowed]
-|CKV3_SAST_84
-|LOW
-
-|xref:sast-policy-85.adoc[AngularJS Misconfiguration Strict Contextual Escaping Disabled]
-|CKV3_SAST_85
-|MEDIUM
-
-|xref:sast-policy-92.adoc[Detection of XSS vulnerability]
-|CKV3_SAST_92
-|LOW
 
 |xref:sast-policy-95.adoc[Cookie Security Overly Permissive Samesite Attribute]
 |CKV3_SAST_95
-|MEDIUM
-
-|xref:sast-policy-101.adoc[Insecure SSL Server Identity Verification Disabled]
-|CKV3_SAST_101
-|MEDIUM
-
-|xref:sast-policy-146.adoc[Ensure Usage of JWT Algo]
-|CKV3_SAST_146
-|MEDIUM
-
-|xref:sast-policy-153.adoc[Sensitive Data Logging]
-|CKV3_SAST_153
 |MEDIUM
 
 |xref:sast-policy-157.adoc[Cross-Site Request Forgery (CSRF)]
 |CKV3_SAST_157
 |MEDIUM
 
-|xref:sast-policy-158.adoc[Improper restriction of operations within the bounds of a memory buffer]
-|CKV3_SAST_158
+|xref:sast-policy-33.adoc[Encryption Keys are less than 16 bytes]
+|CKV3_SAST_33
 |MEDIUM
 
-|xref:sast-policy-159.adoc[Incorrect regular expression]
-|CKV3_SAST_159
+|xref:sast-policy-80.adoc[Enforce HTTPS Access for S3 Buckets]
+|CKV3_SAST_80
 |MEDIUM
 
-|xref:sast-policy-160.adoc[Information Exposure Through an Error Message]
-|CKV3_SAST_160
+|xref:sast-policy-146.adoc[Ensure Usage of JWT Algo]
+|CKV3_SAST_146
 |MEDIUM
 
-|xref:sast-policy-161.adoc[Observable timing discrepancy]
-|CKV3_SAST_161
+|xref:sast-policy-34.adoc[Hash used without salt]
+|CKV3_SAST_34
+|MEDIUM
+
+|xref:sast-policy-74.adoc[Insecure communication using postMessage and event listeners]
+|CKV3_SAST_74
+|MEDIUM
+
+|xref:sast-policy-31.adoc[Insecure use of crypto.pseudoRandomBytes]
+|CKV3_SAST_31
 |MEDIUM
 
 |xref:sast-policy-176.adoc[Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)]
@@ -149,8 +89,68 @@
 |CKV3_SAST_178
 |MEDIUM
 
+|xref:sast-policy-158.adoc[Improper restriction of operations within the bounds of a memory buffer]
+|CKV3_SAST_158
+|MEDIUM
+
+|xref:sast-policy-159.adoc[Incorrect regular expression]
+|CKV3_SAST_159
+|MEDIUM
+
+|xref:sast-policy-160.adoc[Information Exposure Through an Error Message]
+|CKV3_SAST_160
+|MEDIUM
+
+|xref:sast-policy-101.adoc[Insecure SSL Server Identity Verification Disabled]
+|CKV3_SAST_101
+|MEDIUM
+
+|xref:sast-policy-41.adoc[Insecure use of `eval` with non-string parameters]
+|CKV3_SAST_41
+|MEDIUM
+
+|xref:sast-policy-161.adoc[Observable timing discrepancy]
+|CKV3_SAST_161
+|MEDIUM
+
+|xref:sast-policy-81.adoc[Prevent OS Command Argument Injections]
+|CKV3_SAST_81
+|MEDIUM
+
+|xref:sast-policy-79.adoc[Prevent Public Network Access to Cloud Resources]
+|CKV3_SAST_79
+|MEDIUM
+
+|xref:sast-policy-78.adoc[Restrict Unnecessary Powerful Browser Features]
+|CKV3_SAST_78
+|MEDIUM
+
+|xref:sast-policy-153.adoc[Sensitive Data Logging]
+|CKV3_SAST_153
+|MEDIUM
+
+|xref:sast-policy-36.adoc[Superuser port is set]
+|CKV3_SAST_36
+|MEDIUM
+
+|xref:sast-policy-39.adoc[Use of insecure HTTP connections]
+|CKV3_SAST_39
+|MEDIUM
+
+|xref:sast-policy-77.adoc[Weak SSL/TLS protocols]
+|CKV3_SAST_77
+|MEDIUM
+
+|xref:sast-policy-84.adoc[AngularJS misconfiguration dangerous protocol allowed]
+|CKV3_SAST_84
+|LOW
+
 |xref:sast-policy-28.adoc[CSRF is not used before `methodOverride`]
 |CKV3_SAST_28
+|LOW
+
+|xref:sast-policy-92.adoc[Detection of XSS vulnerability]
+|CKV3_SAST_92
 |LOW
 
 |xref:sast-policy-27.adoc[Escape markup is removed leading to risk for XSS]
@@ -164,6 +164,5 @@
 |xref:sast-policy-40.adoc[Use of insecure HTTP Connections with Axios]
 |CKV3_SAST_40
 |LOW
-
 
 |===

--- a/docs/en/enterprise-edition/policy-reference/sast-policies/python-policies/sast-python-policy-index.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/python-policies/sast-python-policy-index.adoc
@@ -85,10 +85,6 @@
 |CKV3_SAST_2
 |HIGH
 
-|xref:sast-policy-6.adoc[Use of hardcoded passwords in Python code]
-|CKV3_SAST_6
-|HIGH
-
 |xref:sast-policy-37.adoc[Use of insecure IPMI-related modules]
 |CKV3_SAST_37
 |HIGH
@@ -121,18 +117,6 @@
 |CKV3_SAST_60
 |MEDIUM
 
-|xref:sast-policy-70.adoc[Improper Authorization in Handler for Custom URL Scheme]
-|CKV3_SAST_70
-|MEDIUM
-
-|xref:sast-policy-94.adoc[Improper Certificate Validation]
-|CKV3_SAST_94
-|MEDIUM
-
-|xref:sast-policy-100.adoc[Improper Check or Handling of Exceptional Conditions]
-|CKV3_SAST_100
-|LOW
-
 |xref:sast-policy-168.adoc[Improper Control of Generation of Code ('Code Injection')]
 |CKV3_SAST_168
 |MEDIUM
@@ -153,16 +137,8 @@
 |CKV3_SAST_170
 |MEDIUM
 
-|xref:sast-policy-90.adoc[Improper Restriction of XML External Entity Reference]
-|CKV3_SAST_90
-|MEDIUM
-
 |xref:sast-policy-96.adoc[Insecure active debug code]
 |CKV3_SAST_96
-|MEDIUM
-
-|xref:sast-policy-99.adoc[Insecure temporary file]
-|CKV3_SAST_99
 |MEDIUM
 
 |xref:sast-policy-66.adoc[LDAP anonymous binds are used]
@@ -208,10 +184,6 @@
 |xref:sast-policy-50.adoc[XML Parsers exposed to XXE Vulnerabilities]
 |CKV3_SAST_50
 |MEDIUM
-
-|xref:sast-policy-166.adoc[Improper Check or Handling of Exceptional Conditions]
-|CKV3_SAST_166
-|LOW
 
 |xref:sast-policy-5.adoc[Publicly exposed servers]
 |CKV3_SAST_5

--- a/docs/en/enterprise-edition/policy-reference/sast-policies/python-policies/sast-python-policy-index.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/python-policies/sast-python-policy-index.adoc
@@ -5,109 +5,97 @@
 |===
 |Policy|Checkov ID| Severity
 
-|xref:sast-policy-2.adoc[Unsafe use of 'exec' command]
-|CKV3_SAST_2
-|HIGH
+|xref:sast-policy-89.adoc[Cross-site scripting (XSS) exposure]
+|CKV3_SAST_89
+|CRITICAL
+
+|xref:sast-policy-71.adoc[Insecure use of no password or weak password when connecting to a database]
+|CKV3_SAST_71
+|CRITICAL
+
+|xref:sast-policy-61.adoc[LDAP Queries Should Not Be Vulnerable to Injection Attacks]
+|CKV3_SAST_61
+|CRITICAL
+
+|xref:sast-policy-58.adoc[Untrusted data unsafely deserialized]
+|CKV3_SAST_58
+|CRITICAL
 
 |xref:sast-policy-3.adoc[chmod sets a permissive mask on file]
 |CKV3_SAST_3
 |HIGH
 
-|xref:sast-policy-4.adoc[Improper handling of checking for unusual or exceptional conditions]
-|CKV3_SAST_4
-|MEDIUM
-
-|xref:sast-policy-5.adoc[Publicly exposed servers]
-|CKV3_SAST_5
-|LOW
-
-|xref:sast-policy-6.adoc[Use of hardcoded passwords in Python code]
-|CKV3_SAST_6
-|HIGH
-
-|xref:sast-policy-10.adoc[Encryption keys below 2048 bit]
-|CKV3_SAST_10
-|MEDIUM
-
-|xref:sast-policy-11.adoc[Use of module setting superuser port]
-|CKV3_SAST_11
-|LOW
-
-|xref:sast-policy-37.adoc[Use of insecure IPMI-related modules]
-|CKV3_SAST_37
-|HIGH
-
-|xref:sast-policy-48.adoc[Unsanitized input from data from a remote resource flows into os.system]
-|CKV3_SAST_48
-|MEDIUM
-
-|xref:sast-policy-50.adoc[XML Parsers exposed to XXE Vulnerabilities]
-|CKV3_SAST_50
-|MEDIUM
-
-|xref:sast-policy-51.adoc[Request exposed to SQL injection]
-|CKV3_SAST_51
-|HIGH
-
-|xref:sast-policy-52.adoc[User input not protected against NoSQL injection]
-|CKV3_SAST_52
-|MEDIUM
-
-|xref:sast-policy-53.adoc[Not using HttpOnly flag when setting cookies]
-|CKV3_SAST_53
-|MEDIUM
-
-|xref:sast-policy-54.adoc[JWTs are not properly verified before decoding]
-|CKV3_SAST_54
-|HIGH
-
-|xref:sast-policy-55.adoc[Weak cryptographic algorithm used]
-|CKV3_SAST_55
+|xref:sast-policy-93.adoc[Cleartext Transmission of Sensitive Information]
+|CKV3_SAST_93
 |HIGH
 
 |xref:sast-policy-56.adoc[CSRF protections disabled]
 |CKV3_SAST_56
 |HIGH
 
-|xref:sast-policy-57.adoc[Improper logger configuration]
-|CKV3_SAST_57
-|MEDIUM
-
-|xref:sast-policy-58.adoc[Untrusted data unsafely deserialized]
-|CKV3_SAST_58
-|CRITICAL
+|xref:sast-policy-87.adoc[Dynamic code execution (vulnerable to injection attacks)]
+|CKV3_SAST_87
+|HIGH
 
 |xref:sast-policy-59.adoc[Encryption algorithms used with an insecure mode or padding]
 |CKV3_SAST_59
 |HIGH
 
-|xref:sast-policy-60.adoc[HTML Autoescape Mechanism Should Not Be Globally Disabled]
-|CKV3_SAST_60
-|MEDIUM
+|xref:sast-policy-152.adoc[Hardcoded passwords are being used]
+|CKV3_SAST_152
+|HIGH
 
-|xref:sast-policy-61.adoc[LDAP Queries Should Not Be Vulnerable to Injection Attacks]
-|CKV3_SAST_61
-|CRITICAL
+|xref:sast-policy-88.adoc[HTTP response headers should not be vulnerable to injection attacks]
+|CKV3_SAST_88
+|HIGH
 
-|xref:sast-policy-62.adoc[Logging Should Not Be Vulnerable to Injection Attacks]
-|CKV3_SAST_62
-|MEDIUM
+|xref:sast-policy-97.adoc[Improper access control]
+|CKV3_SAST_97
+|HIGH
 
-|xref:sast-policy-63.adoc[Sending Emails is Security-Sensitive]
-|CKV3_SAST_63
-|LOW
-
-|xref:sast-policy-64.adoc[Server Hostnames Should not verified during SSL/TLS connections]
-|CKV3_SAST_64
-|MEDIUM
+|xref:sast-policy-169.adoc[Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')]
+|CKV3_SAST_169
+|HIGH
 
 |xref:sast-policy-65.adoc[Inadequate Encryption Strength]
 |CKV3_SAST_65
 |HIGH
 
-|xref:sast-policy-66.adoc[LDAP anonymous binds are used]
-|CKV3_SAST_66
-|MEDIUM
+|xref:sast-policy-54.adoc[JWTs are not properly verified before decoding]
+|CKV3_SAST_54
+|HIGH
+
+|xref:sast-policy-98.adoc[Key Exchange without Entity Authentication]
+|CKV3_SAST_98
+|HIGH
+
+|xref:sast-policy-86.adoc[Path injection]
+|CKV3_SAST_86
+|HIGH
+
+|xref:sast-policy-173.adoc[Relative Path Traversal]
+|CKV3_SAST_173
+|HIGH
+
+|xref:sast-policy-51.adoc[Request exposed to SQL injection]
+|CKV3_SAST_51
+|HIGH
+
+|xref:sast-policy-2.adoc[Unsafe use of 'exec' command]
+|CKV3_SAST_2
+|HIGH
+
+|xref:sast-policy-6.adoc[Use of hardcoded passwords in Python code]
+|CKV3_SAST_6
+|HIGH
+
+|xref:sast-policy-37.adoc[Use of insecure IPMI-related modules]
+|CKV3_SAST_37
+|HIGH
+
+|xref:sast-policy-55.adoc[Weak cryptographic algorithm used]
+|CKV3_SAST_55
+|HIGH
 
 |xref:sast-policy-67.adoc[Weak SSL/TLS protocol used]
 |CKV3_SAST_67
@@ -117,117 +105,128 @@
 |CKV3_SAST_68
 |HIGH
 
+|xref:sast-policy-10.adoc[Encryption keys below 2048 bit]
+|CKV3_SAST_10
+|MEDIUM
+
 |xref:sast-policy-69.adoc[Files and directories are assigned loose permissions]
 |CKV3_SAST_69
+|MEDIUM
+
+|xref:sast-policy-72.adoc[Hash functions used without an unpredictable salt]
+|CKV3_SAST_72
+|MEDIUM
+
+|xref:sast-policy-60.adoc[HTML Autoescape Mechanism Should Not Be Globally Disabled]
+|CKV3_SAST_60
 |MEDIUM
 
 |xref:sast-policy-70.adoc[Improper Authorization in Handler for Custom URL Scheme]
 |CKV3_SAST_70
 |MEDIUM
 
-|xref:sast-policy-71.adoc[Insecure use of no password or weak password when connecting to a database]
-|CKV3_SAST_71
-|CRITICAL
-
-|xref:sast-policy-72.adoc[Hash functions used without an unpredictable salt]
-|CKV3_SAST_72
-|MEDIUM
-
-|xref:sast-policy-73.adoc[None attributes accessed]
-|CKV3_SAST_73
-|MEDIUM
-
-|xref:sast-policy-82.adoc[Writing unvalidated input into JSON]
-|CKV3_SAST_82
-|MEDIUM
-
-|xref:sast-policy-86.adoc[Path injection]
-|CKV3_SAST_86
-|HIGH
-
-|xref:sast-policy-87.adoc[Dynamic code execution (vulnerable to injection attacks)]
-|CKV3_SAST_87
-|HIGH
-
-|xref:sast-policy-88.adoc[HTTP response headers should not be vulnerable to injection attacks]
-|CKV3_SAST_88
-|HIGH
-
-|xref:sast-policy-89.adoc[Cross-site scripting (XSS) exposure]
-|CKV3_SAST_89
-|CRITICAL
-
-|xref:sast-policy-90.adoc[Improper Restriction of XML External Entity Reference]
-|CKV3_SAST_90
-|MEDIUM
-
-|xref:sast-policy-91.adoc[Uncontrolled Resource Consumption]
-|CKV3_SAST_91
-|MEDIUM
-
-|xref:sast-policy-93.adoc[Cleartext Transmission of Sensitive Information]
-|CKV3_SAST_93
-|HIGH
-
 |xref:sast-policy-94.adoc[Improper Certificate Validation]
 |CKV3_SAST_94
-|MEDIUM
-
-|xref:sast-policy-96.adoc[Insecure active debug code]
-|CKV3_SAST_96
-|MEDIUM
-
-|xref:sast-policy-97.adoc[Improper access control]
-|CKV3_SAST_97
-|HIGH
-
-|xref:sast-policy-98.adoc[Key Exchange without Entity Authentication]
-|CKV3_SAST_98
-|HIGH
-
-|xref:sast-policy-99.adoc[Insecure temporary file]
-|CKV3_SAST_99
 |MEDIUM
 
 |xref:sast-policy-100.adoc[Improper Check or Handling of Exceptional Conditions]
 |CKV3_SAST_100
 |LOW
 
-|xref:sast-policy-152.adoc[Hardcoded passwords are being used]
-|CKV3_SAST_152
-|HIGH
+|xref:sast-policy-168.adoc[Improper Control of Generation of Code ('Code Injection')]
+|CKV3_SAST_168
+|MEDIUM
+
+|xref:sast-policy-4.adoc[Improper handling of checking for unusual or exceptional conditions]
+|CKV3_SAST_4
+|MEDIUM
+
+|xref:sast-policy-57.adoc[Improper logger configuration]
+|CKV3_SAST_57
+|MEDIUM
+
+|xref:sast-policy-175.adoc[Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)]
+|CKV3_SAST_175
+|MEDIUM
+
+|xref:sast-policy-170.adoc[Improper Neutralization of Wildcards or Matching Symbols]
+|CKV3_SAST_170
+|MEDIUM
+
+|xref:sast-policy-90.adoc[Improper Restriction of XML External Entity Reference]
+|CKV3_SAST_90
+|MEDIUM
+
+|xref:sast-policy-96.adoc[Insecure active debug code]
+|CKV3_SAST_96
+|MEDIUM
+
+|xref:sast-policy-99.adoc[Insecure temporary file]
+|CKV3_SAST_99
+|MEDIUM
+
+|xref:sast-policy-66.adoc[LDAP anonymous binds are used]
+|CKV3_SAST_66
+|MEDIUM
+
+|xref:sast-policy-62.adoc[Logging Should Not Be Vulnerable to Injection Attacks]
+|CKV3_SAST_62
+|MEDIUM
+
+|xref:sast-policy-73.adoc[None attributes accessed]
+|CKV3_SAST_73
+|MEDIUM
+
+|xref:sast-policy-53.adoc[Not using HttpOnly flag when setting cookies]
+|CKV3_SAST_53
+|MEDIUM
+
+|xref:sast-policy-64.adoc[Server Hostnames Should not verified during SSL/TLS connections]
+|CKV3_SAST_64
+|MEDIUM
+
+|xref:sast-policy-91.adoc[Uncontrolled Resource Consumption]
+|CKV3_SAST_91
+|MEDIUM
+
+|xref:sast-policy-48.adoc[Unsanitized input from data from a remote resource flows into os.system]
+|CKV3_SAST_48
+|MEDIUM
 
 |xref:sast-policy-154.adoc[Unsanitized path input from an HTTP parameter is being opened]
 |CKV3_SAST_154
+|MEDIUM
+
+|xref:sast-policy-52.adoc[User input not protected against NoSQL injection]
+|CKV3_SAST_52
+|MEDIUM
+
+|xref:sast-policy-82.adoc[Writing unvalidated input into JSON]
+|CKV3_SAST_82
+|MEDIUM
+
+|xref:sast-policy-50.adoc[XML Parsers exposed to XXE Vulnerabilities]
+|CKV3_SAST_50
 |MEDIUM
 
 |xref:sast-policy-166.adoc[Improper Check or Handling of Exceptional Conditions]
 |CKV3_SAST_166
 |LOW
 
+|xref:sast-policy-5.adoc[Publicly exposed servers]
+|CKV3_SAST_5
+|LOW
+
+|xref:sast-policy-63.adoc[Sending Emails is Security-Sensitive]
+|CKV3_SAST_63
+|LOW
+
 |xref:sast-policy-167.adoc[Use of Insufficiently Random Values]
 |CKV3_SAST_167
 |LOW
 
-|xref:sast-policy-168.adoc[Improper Control of Generation of Code ('Code Injection')]
-|CKV3_SAST_168
-|MEDIUM
-
-|xref:sast-policy-169.adoc[Improper Limitation of a Pathname to a Restricted Directory ('Path Traversal')]
-|CKV3_SAST_169
-|HIGH
-
-|xref:sast-policy-170.adoc[Improper Neutralization of Wildcards or Matching Symbols]
-|CKV3_SAST_170
-|MEDIUM
-
-|xref:sast-policy-173.adoc[Relative Path Traversal]
-|CKV3_SAST_173
-|HIGH
-
-|xref:sast-policy-175.adoc[Improper Neutralization of Script-Related HTML Tags in a Web Page (Basic XSS)]
-|CKV3_SAST_175
-|MEDIUM
-
+|xref:sast-policy-11.adoc[Use of module setting superuser port]
+|CKV3_SAST_11
+|LOW
 
 |===


### PR DESCRIPTION
 Resorted Java, JavaScript and Python policies according to severity (critical to low) with alphabetical subsorting within a severity.
