### PR TITLE
Update release-notes-32-01.adoc

### DIFF
--- a/docs/en/compute-edition/32/rn/release-information/release-notes-32-01.adoc
+++ b/docs/en/compute-edition/32/rn/release-information/release-notes-32-01.adoc
@@ -6,7 +6,7 @@ The following table outlines the release particulars:
 [cols="1,4"]
 |===
 |Build
-|31.02.128
+|32.02.128
 
 |Code name
 |O'Neal - Update 1, 32.01


### PR DESCRIPTION
There is a typo on the Build version.  It is currently 31.02.128, but it should be 31.02.128.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
