### PR TITLE
Change cgi.escape to html.escape

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/sast-policies/python-policies/sast-policy-175.adoc
+++ b/docs/en/enterprise-edition/policy-reference/sast-policies/python-policies/sast-policy-175.adoc
@@ -57,14 +57,14 @@ Secure code example:
 [source,python]
 ----
 from flask import request, render_template
-import cgi
+import html
 
 @app.route('/example')
 def example():
-    user_input = cgi.escape(request.args.get('user_input'))
+    user_input = html.escape(request.args.get('user_input'))
     return render_template('example.html', input=user_input)
 ----
 
-In the Improved code, the user's input goes through the 'cgi.escape()' function which neutralizes any potential script-related HTML tags. Thus, it makes it safe to include in the rendered web page.
+In the improved code, the user's input goes through the 'html.escape()' function which neutralizes any potential script-related HTML tags. Thus, it makes it safe to include in the rendered web page.  'cgi.escape()' will also pass but note that it has been deprecated in favour of 'html.escape()'.
 
     


### PR DESCRIPTION
cgi was deprecated early in Python 3.x
html is the new cgi

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
