### PR TITLE
fixing incorrect compliance id

### DIFF
--- a/docs/en/classic/compute-admin-guide/compliance/detect-secrets.adoc
+++ b/docs/en/classic/compute-admin-guide/compliance/detect-secrets.adoc
@@ -67,14 +67,14 @@ Agentless scanning detects sensitive information inside files in your hosts and 
 
 ==== Compliance Check ID 456
 
-This check detects secrets inside your hosts' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a host.
+This check detects secrets inside your container images' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a container image.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 ==== Compliance Check ID 457
 
-This check detects secrets inside your container images' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a container image.
+This check detects secrets inside your hosts' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a host.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 [#detected-secrets]

--- a/docs/en/compute-edition/31/admin-guide/compliance/detect-secrets.adoc
+++ b/docs/en/compute-edition/31/admin-guide/compliance/detect-secrets.adoc
@@ -67,14 +67,14 @@ Agentless scanning detects sensitive information inside files in your hosts and 
 
 ==== Compliance Check ID 456
 
-This check detects secrets inside your hosts' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a host.
+This check detects secrets inside your container images' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a container image.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 ==== Compliance Check ID 457
 
-This check detects secrets inside your container images' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a container image.
+This check detects secrets inside your hosts' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a host.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 [#detected-secrets]

--- a/docs/en/compute-edition/32/admin-guide/compliance/detect-secrets.adoc
+++ b/docs/en/compute-edition/32/admin-guide/compliance/detect-secrets.adoc
@@ -67,14 +67,14 @@ Agentless scanning detects sensitive information inside files in your hosts and 
 
 ==== Compliance Check ID 456
 
-This check detects secrets inside your hosts' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a host.
+This check detects secrets inside your container images' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a container image.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 ==== Compliance Check ID 457
 
-This check detects secrets inside your container images' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a container image.
+This check detects secrets inside your hosts' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a host.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 [#detected-secrets]

--- a/docs/en/enterprise-edition/content-collections/runtime-security/compliance/operations/detect-secrets.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/compliance/operations/detect-secrets.adoc
@@ -67,14 +67,14 @@ Agentless scanning detects sensitive information inside files in your hosts and 
 
 ==== Compliance Check ID 456
 
-This check detects secrets inside your hosts' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a host.
+This check detects secrets inside your container images' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a container image.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 ==== Compliance Check ID 457
 
-This check detects secrets inside your container images' filesystem.
-By default, Prisma Cloud alerts you that a secret was detected in a container image.
+This check detects secrets inside your hosts' filesystem.
+By default, Prisma Cloud alerts you that a secret was detected in a host.
 Select *Monitor > Compliance > Compliance Explorer* and search the results using the compliance check ID.
 
 [#detected-secrets]


### PR DESCRIPTION
The ID's need to be swapped for container and host secret scanning:

![image](https://github.com/hlxsites/prisma-cloud-docs/assets/13968804/6b0522bf-436d-44ab-8abb-960a29283185)

![image](https://github.com/hlxsites/prisma-cloud-docs/assets/13968804/26745e75-f65b-4e69-b1f2-60badd0a825b)

@jenjoe22 

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
