### PR TITLE
Remove references to Date Filter

### DIFF
--- a/docs/en/enterprise-edition/content-collections/cloud-and-software-inventory/asset-inventory.adoc
+++ b/docs/en/enterprise-edition/content-collections/cloud-and-software-inventory/asset-inventory.adoc
@@ -9,9 +9,7 @@ Each row displays the service name with details on the cloud type, assets with a
 
 image::cloud-and-software-inventory/asset-inventory-1.png[]
 
-The *Assets with Alerts* column displays the total number of assets by alert severity for a specified group of assets and the *Assets with Vulnerabilities* column displays the total number of assets by vulnerability severity for a specified group of assets. You can filter to view the inventory based on Date, Cloud Type, Azure Resource Group, Compliance Requirement, Compliance Standard, Asset Type, Compliance Section, Account Group, Cloud Account, Cloud Region, Alert Severity, and Vulnerability Severity. 
-
-You can set the *Date* filter to *Most Recent* to view the most recent state of the inventory or choose *Custom* for any date within the last 90 days.
+The *Assets with Alerts* column displays the total number of assets by alert severity for a specified group of assets and the *Assets with Vulnerabilities* column displays the total number of assets by vulnerability severity for a specified group of assets. You can filter to view the inventory based on Cloud Type, Azure Resource Group, Compliance Requirement, Compliance Standard, Asset Type, Compliance Section, Account Group, Cloud Account, Cloud Region, Alert Severity, and Vulnerability Severity. 
 
 You can view the *Asset Explorer* by selecting a filterable subset of assets from the Asset Inventory. You can then select an asset from the Explorer view to access the Asset Detail view. Vulnerability Severity displays assets with known software vulnerabilities of a specific severity while Alert Severity displays assets with open alerts of a specific severity. You can use the Column Picker to show or hide columns.
 


### PR DESCRIPTION
Date Filtering is being deprecated and needs to be removed from the Documentation in coordination with that deprecation.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
