### PR TITLE
Update prisma-cloud-alert-notifications.adoc for Global region resources

### DIFF
--- a/docs/en/classic/cspm-admin-guide/manage-prisma-cloud-alerts/prisma-cloud-alert-notifications.adoc
+++ b/docs/en/classic/cspm-admin-guide/manage-prisma-cloud-alerts/prisma-cloud-alert-notifications.adoc
@@ -23,4 +23,6 @@ In addition, Prisma Cloud provides out-of-box ability to xref:../configure-exter
 NOTE: Alerts associated with active cloud accounts are currently kept for the duration of the service. When cloud accounts are deleted from Prisma Cloud, the associated alerts are held for an additional 24 hours after which they arepermanently deleted. Configuration of assets active in the cloud environment is retained for the
 duration of the service as well. Upon termination of the service, data in live systems is stored for up to 60 days, after which it will be deleted from live systems. Purge of backup data may take up to an additional 60 days.
 
+NOTE: Resources which are global region in nature, will be subjected to match to any Alert Rule irrespective of regions configured.
+
 


### PR DESCRIPTION
RLP-117649: Resources which are global region in nature will be subjected to match to any Alert Rule irrespective of regions configured.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
