### PR TITLE
[Runtime Security]Fix image rendering in fragments

### DIFF
--- a/docs/en/classic/compute-admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
+++ b/docs/en/classic/compute-admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
@@ -5,7 +5,7 @@
 Agentless scans start immediately after onboarding the cloud account.
 By default, agentless scans are performed every 24 hours, but you can change the interval on the *Manage > System > Scan* page under *Scheduling > Agentless*.
 
-image::agentless-interval.png[width=800]
+// image::agentless-interval.png[width=800]
 
 To manually start a scan, complete the following steps.
 
@@ -22,8 +22,8 @@ endif::prisma_cloud[]
 . Click the scan icon on the top right corner of the accounts table.
 
 . Click *Start Agentless scan*.
-+
-image::agentless-start-scan.png[width=400]
+// +
+// image::agentless-start-scan.png[width=400]
 
 . Click the scan icon in the top right corner of the console to view the scan status.
 
@@ -38,13 +38,13 @@ ifdef::prisma_cloud[]
 endif::prisma_cloud[]
 
 .. Click on the *Filter hosts* text bar.
-+
-image::vulnerability-results-filters.png[width=400]
+// +
+// image::vulnerability-results-filters.png[width=400]
 
 .. Select the *Scanned by* filter.
-+
-image::vulnerability-results-scanned-by.png[width=400]
+// +
+// image::vulnerability-results-scanned-by.png[width=400]
 
 .. Select the *Agentless* filter.
-+
-image::vulnerability-results-scanned-by-agentless.png[width=400]
+// +
+// image::vulnerability-results-scanned-by-agentless.png[width=400]

--- a/docs/en/classic/compute-admin-guide/alerts/frag-config-triggers.adoc
+++ b/docs/en/classic/compute-admin-guide/alerts/frag-config-triggers.adoc
@@ -8,24 +8,24 @@
 . In *Select triggers*, select the events that should trigger an alert to be sent.
 
 . To specify specific rules that should trigger an alert, deselect *All rules*, and then select any individual rules.
-+
-ifdef::jira_alerts[]
-image::frag_config_jira_triggers.png[scale=15]
-endif::jira_alerts[]
+// +
+// ifdef::jira_alerts[]
+// image::frag_config_jira_triggers.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::servicenow_vr_alerts[]
-+
-image::frag_config_servicenow_vr_triggers.png[scale=15]
-endif::servicenow_vr_alerts[]
+// ifdef::servicenow_vr_alerts[]
+// +
+// image::frag_config_servicenow_vr_triggers.png[scale=15]
+// endif::servicenow_vr_alerts[]
 
-ifdef::cortex_xdr_alerts[]
-+
-image::cortex-xdr-config-triggers.png[scale=15]
-endif::cortex_xdr_alerts[]
+// ifdef::cortex_xdr_alerts[]
+// +
+// image::cortex-xdr-config-triggers.png[scale=15]
+// endif::cortex_xdr_alerts[]
 
-ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
-+
-image::frag_config_triggers.png[scale=15]
-endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// +
+// image::frag_config_triggers.png[scale=15]
+// endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
 
 . Click *Next*.

--- a/docs/en/classic/compute-admin-guide/alerts/frag-send-alerts.adoc
+++ b/docs/en/classic/compute-admin-guide/alerts/frag-send-alerts.adoc
@@ -8,58 +8,58 @@ Configure Prisma Cloud to integrate with your messaging service and specify the 
 For example, configure the email channel and specify a list of all the email addresses where alerts should be sent.
 Or for JIRA, configure the project where the issue should be created, along with the type of issue, priority, assignee, and so on.
 
-ifdef::email_alerts[]
-image::email-config-1.png[scale=15]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// image::email-config-1.png[scale=15]
+// endif::email_alerts[]
 
-ifdef::webhook_alerts[]
-image::webhook-config-1.png[width=250]
-endif::webhook_alerts[]
+// ifdef::webhook_alerts[]
+// image::webhook-config-1.png[width=250]
+// endif::webhook_alerts[]
 
-ifdef::slack_alerts[]
-image::slack-config-1.png[scale=15]
-endif::slack_alerts[]
+// ifdef::slack_alerts[]
+// image::slack-config-1.png[scale=15]
+// endif::slack_alerts[]
 
 *(2) Alert triggers -- Which events should trigger an alert to be sent?*
 Specify which of the rules that make up your overall policy should trigger alerts.
 
-ifdef::aws_security_hub[]
-image::aws_security_hub_config.png[scale=15]
-endif::aws_security_hub[]
+// ifdef::aws_security_hub[]
+// image::aws_security_hub_config.png[scale=15]
+// endif::aws_security_hub[]
 
-ifdef::email_alerts[]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// endif::email_alerts[]
 
-ifdef::google_cloud_pub_sub[]
-image::google_cloud_pub_sub_config.png[scale=15]
-endif::google_cloud_pub_sub[]
+// ifdef::google_cloud_pub_sub[]
+// image::google_cloud_pub_sub_config.png[scale=15]
+// endif::google_cloud_pub_sub[]
 
-ifdef::google_cloud_scc[]
-image::google_cloud_scc_config.png[scale=15]
-endif::google_cloud_scc[]
+// ifdef::google_cloud_scc[]
+// image::google_cloud_scc_config.png[scale=15]
+// endif::google_cloud_scc[]
 
-ifdef::ibm_cloud_security_advisor[]
-image::ibm_cloud_security_advisor_config.png[scale=15]
-endif::ibm_cloud_security_advisor[]
+// ifdef::ibm_cloud_security_advisor[]
+// image::ibm_cloud_security_advisor_config.png[scale=15]
+// endif::ibm_cloud_security_advisor[]
 
-ifdef::jira_alerts[]
-image::jira_config.png[scale=15]
-endif::jira_alerts[]
+// ifdef::jira_alerts[]
+// image::jira_config.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::pagerduty_alerts[]
-image::pagerduty_config.png[scale=15]
-endif::pagerduty_alerts[]
+// ifdef::pagerduty_alerts[]
+// image::pagerduty_config.png[scale=15]
+// endif::pagerduty_alerts[]
 
-ifdef::slack_alerts,webhook_alerts[]
-image::slack-config-2.png[width=250]
-endif::slack_alerts,webhook_alerts[]
+// ifdef::slack_alerts,webhook_alerts[]
+// image::slack-config-2.png[width=250]
+// endif::slack_alerts,webhook_alerts[]
 
-ifdef::xdr_alerts[]
-image::cortex_xdr_config.png[scale=15]
-endif::xdr_alerts[]
+// ifdef::xdr_alerts[]
+// image::cortex_xdr_config.png[scale=15]
+// endif::xdr_alerts[]
 
-ifdef::xsoar_alerts[]
-image::cortex_xsoar_config.png[scale=15]
-endif::xsoar_alerts[]
+// ifdef::xsoar_alerts[]
+// image::cortex_xsoar_config.png[scale=15]
+// endif::xsoar_alerts[]
 
 If you use multi-factor authentication, you must create an exception or app-specific password to allow Console to authenticate to the service.

--- a/docs/en/classic/compute-admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
+++ b/docs/en/classic/compute-admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
@@ -132,12 +132,12 @@ Confirm the installation was successful.
 
 [.procedure]
 . In Prisma Cloud Console, go to *Compute > Manage > Defenders > Manage* to see a list of deployed Defenders.
-+
-image::install_openshift_tl_defenders.png[width=800]
+// +
+// image::install_openshift_tl_defenders.png[width=800]
 
 . In the OpenShift Web Console, go to the Prisma Cloud project's monitoring window to see which pods are running.
-+
-image::install_openshift_ose_defenders.png[width=800]
+// +
+// image::install_openshift_ose_defenders.png[width=800]
 
 . Use the OpenShift CLI to see the DaemonSet pod count.
 

--- a/docs/en/classic/compute-admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
+++ b/docs/en/classic/compute-admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
@@ -38,8 +38,8 @@ Base path for WAAS to match when applying protections.
 Examples: "/admin", "/" (root path only), "/*", /v2/api", etc.
 ifdef::waas_port[]
 .. Enter *WAAS port (only required for Windows, App-Embedded or when using xref:../waas-advanced-settings.adoc#remote-host["Remote host"] option)* as the external port WAAS listens on. The external port is the TCP port for the App-Embedded Defender to listen on for inbound HTTP traffic.
-+
-image::cwp-42473-add-app-waas-port-windows.png[scale=15]
+// +
+// image::cwp-42473-add-app-waas-port-windows.png[scale=15]
 endif::waas_port[]
 ifdef::waas_hosts[]
 +
@@ -69,22 +69,22 @@ WAAS must be able to decrypt and inspect HTTPS traffic to function properly.
 endif::waas_oob[]
 ifdef::response_headers[]
 .. You can select *Response headers* to add or override HTTP response headers in responses sent from the protected application.
-+
-image::waas_response_headers.png[width=550] 
+// +
+// image::waas_response_headers.png[width=550]
 endif::response_headers[]
 .. Select *Create response header*.
 
 .. To facilitate inspection, after creating all endpoints, click *View TLS settings* in the endpoint setup menu.
-+
-WAAS TLS settings:
-+
-ifndef::waas_oob[]
-image::waas-inline-app-embedded-tls.png[scale=15]
-endif::waas_oob[]
+// +
+// WAAS TLS settings:
+// +
+// ifndef::waas_oob[]
+// image::waas-inline-app-embedded-tls.png[scale=15]
+// endif::waas_oob[]
 
-ifdef::waas_oob[]
-image::waas-oob-tls.png[scale=15]
-endif::waas_oob[]
+// ifdef::waas_oob[]
+// image::waas-oob-tls.png[scale=15]
+// endif::waas_oob[]
 
 * *Certificate* - Copy and paste your server's certificate and private key into the certificate input box (e.g., `cat server-cert.pem server-key > certs.pem`).
 +

--- a/docs/en/classic/compute-admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
+++ b/docs/en/classic/compute-admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
@@ -20,24 +20,24 @@ NOTE: The maximum duration in seconds for reading the entire request, including 
 endif::waas_inline_hosts[]
 
 . Choose the rule *Scope* by specifying the resource collection(s) to which it applies.
-+
-image::waas_select_scope.png[scale=20]
+// +
+// image::waas_select_scope.png[scale=20]
 +
 ifdef::waas_containers[]
 Collections define a combination of image names and one or more elements to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_collection.png[width=250]
+// +
+// image::waas_define_collection.png[width=250]
 +
 NOTE: Applying a rule to all images using a wild card (`*`) is invalid - instead, only specify your web application images.
 endif::waas_containers[]
 
 ifdef::waas_hosts[]
 Collections define a combination of hosts to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_host_collection.png[width=250]
-ifdef::waas_oob_hosts[]
-image::waas_define_collection_oob_hosts.png[width=250]
-endif::waas_oob_hosts[]
+// +
+// image::waas_define_host_collection.png[width=250]
+// ifdef::waas_oob_hosts[]
+// image::waas_define_collection_oob_hosts.png[width=250]
+// endif::waas_oob_hosts[]
 +
 NOTE: Applying a rule to all hosts/images using a wild card (`*`) is invalid and a waste of resources.
 WAAS only needs to be applied to hosts that run applications that transmit and receive HTTP/HTTPS traffic.

--- a/docs/en/classic/compute-admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
+++ b/docs/en/classic/compute-admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
@@ -1,6 +1,6 @@
 AWS CloudFormation stack failed to deploy the WAAS agentless resources because Prisma Console is not accessible from AWS.
 
-image::err4-failedcondition-received.png[width=350]
+// image::err4-failedcondition-received.png[width=350]
 
 . Make sure that the IP address of Prisma Console in the VPC configuration is public.
 . Check if the Defender instance has a public IP address.

--- a/docs/en/compute-edition/22-12/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
+++ b/docs/en/compute-edition/22-12/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
@@ -5,7 +5,7 @@
 Agentless scans start immediately after onboarding the cloud account.
 By default, agentless scans are performed every 24 hours, but you can change the interval on the *Manage > System > Scan* page under *Scheduling > Agentless*.
 
-image::agentless-interval.png[width=800]
+// image::agentless-interval.png[width=800]
 
 To manually start a scan, complete the following steps.
 
@@ -22,8 +22,8 @@ endif::prisma_cloud[]
 . Click the scan icon on the top right corner of the accounts table.
 
 . Click *Start Agentless scan*.
-+
-image::agentless-start-scan.png[width=400]
+// +
+// image::agentless-start-scan.png[width=400]
 
 . Click the scan icon in the top right corner of the console to view the scan status.
 
@@ -38,13 +38,13 @@ ifdef::prisma_cloud[]
 endif::prisma_cloud[]
 
 .. Click on the *Filter hosts* text bar.
-+
-image::vulnerability-results-filters.png[width=400]
+// +
+// image::vulnerability-results-filters.png[width=400]
 
 .. Select the *Scanned by* filter.
-+
-image::vulnerability-results-scanned-by.png[width=400]
+// +
+// image::vulnerability-results-scanned-by.png[width=400]
 
 .. Select the *Agentless* filter.
-+
-image::vulnerability-results-scanned-by-agentless.png[width=400]
+// +
+// image::vulnerability-results-scanned-by-agentless.png[width=400]

--- a/docs/en/compute-edition/22-12/admin-guide/alerts/frag-config-rate.adoc
+++ b/docs/en/compute-edition/22-12/admin-guide/alerts/frag-config-rate.adoc
@@ -13,5 +13,5 @@ All subsequent alerts are sent once per period.
 . In *General settings*, select the default frequency for all alerts.
 +
 You can specify *Second*, *Minute*, *Hour*, *Day*.
-+
-image::frag_configure_alerts.png[scale=15]
+// +
+// image::frag_configure_alerts.png[scale=15]

--- a/docs/en/compute-edition/22-12/admin-guide/alerts/frag-config-triggers.adoc
+++ b/docs/en/compute-edition/22-12/admin-guide/alerts/frag-config-triggers.adoc
@@ -8,24 +8,24 @@
 . In *Select triggers*, select the events that should trigger an alert to be sent.
 
 . To specify specific rules that should trigger an alert, deselect *All rules*, and then select any individual rules.
-+
-ifdef::jira_alerts[]
-image::frag_config_jira_triggers.png[scale=15]
-endif::jira_alerts[]
+// +
+// ifdef::jira_alerts[]
+// image::frag_config_jira_triggers.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::servicenow_vr_alerts[]
-+
-image::frag_config_servicenow_vr_triggers.png[scale=15]
-endif::servicenow_vr_alerts[]
+// ifdef::servicenow_vr_alerts[]
+// +
+// image::frag_config_servicenow_vr_triggers.png[scale=15]
+// endif::servicenow_vr_alerts[]
 
-ifdef::cortex_xdr_alerts[]
-+
-image::cortex-xdr-config-triggers.png[scale=15]
-endif::cortex_xdr_alerts[]
+// ifdef::cortex_xdr_alerts[]
+// +
+// image::cortex-xdr-config-triggers.png[scale=15]
+// endif::cortex_xdr_alerts[]
 
-ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
-+
-image::frag_config_triggers.png[scale=15]
-endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// +
+// image::frag_config_triggers.png[scale=15]
+// endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
 
 . Click *Next*.

--- a/docs/en/compute-edition/22-12/admin-guide/alerts/frag-send-alerts.adoc
+++ b/docs/en/compute-edition/22-12/admin-guide/alerts/frag-send-alerts.adoc
@@ -8,62 +8,62 @@ Configure Prisma Cloud to integrate with your messaging service and specify the 
 For example, configure the email channel and specify a list of all the email addresses where alerts should be sent.
 Or for JIRA, configure the project where the issue should be created, along with the type of issue, priority, assignee, and so on.
 
-ifdef::email_alerts[]
-image::email-config-1.png[scale=15]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// image::email-config-1.png[scale=15]
+// endif::email_alerts[]
 
-ifdef::webhook_alerts[]
-image::webhook-config-1.png[scale=15]
-endif::webhook_alerts[]
+// ifdef::webhook_alerts[]
+// image::webhook-config-1.png[scale=15]
+// endif::webhook_alerts[]
 
-ifdef::slack_alerts[]
-image::slack-config-1.png[scale=15]
-endif::slack_alerts[]
+// ifdef::slack_alerts[]
+// image::slack-config-1.png[scale=15]
+// endif::slack_alerts[]
 
 *(2) Alert triggers -- Which events should trigger an alert to be sent?*
 Specify which of the rules that make up your overall policy should trigger alerts.
 
-ifdef::aws_security_hub[]
-image::aws_security_hub_config.png[scale=15]
-endif::aws_security_hub[]
+// ifdef::aws_security_hub[]
+// image::aws_security_hub_config.png[scale=15]
+// endif::aws_security_hub[]
 
-ifdef::email_alerts[]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// endif::email_alerts[]
 
-ifdef::google_cloud_pub_sub[]
-image::google_cloud_pub_sub_config.png[scale=15]
-endif::google_cloud_pub_sub[]
+// ifdef::google_cloud_pub_sub[]
+// image::google_cloud_pub_sub_config.png[scale=15]
+// endif::google_cloud_pub_sub[]
 
-ifdef::google_cloud_scc[]
-image::google_cloud_scc_config.png[scale=15]
-endif::google_cloud_scc[]
+// ifdef::google_cloud_scc[]
+// image::google_cloud_scc_config.png[scale=15]
+// endif::google_cloud_scc[]
 
-ifdef::ibm_cloud_security_advisor[]
-image::ibm_cloud_security_advisor_config.png[scale=15]
-endif::ibm_cloud_security_advisor[]
+// ifdef::ibm_cloud_security_advisor[]
+// image::ibm_cloud_security_advisor_config.png[scale=15]
+// endif::ibm_cloud_security_advisor[]
 
-ifdef::jira_alerts[]
-image::jira_config.png[scale=15]
-endif::jira_alerts[]
+// ifdef::jira_alerts[]
+// image::jira_config.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::pagerduty_alerts[]
-image::pagerduty_config.png[scale=15]
-endif::pagerduty_alerts[]
+// ifdef::pagerduty_alerts[]
+// image::pagerduty_config.png[scale=15]
+// endif::pagerduty_alerts[]
 
-ifdef::slack_alerts[]
-image::slack-config-2.png[scale=15]
-endif::slack_alerts[]
+// ifdef::slack_alerts[]
+// image::slack-config-2.png[scale=15]
+// endif::slack_alerts[]
 
-ifdef::webhook_alerts[]
-image::webhook-config-2.png[scale=15]
-endif::webhook_alerts[]
+// ifdef::webhook_alerts[]
+// image::webhook-config-2.png[scale=15]
+// endif::webhook_alerts[]
 
-ifdef::xdr_alerts[]
-image::cortex_xdr_config.png[scale=15]
-endif::xdr_alerts[]
+// ifdef::xdr_alerts[]
+// image::cortex_xdr_config.png[scale=15]
+// endif::xdr_alerts[]
 
-ifdef::xsoar_alerts[]
-image::cortex_xsoar_config.png[scale=15]
-endif::xsoar_alerts[]
+// ifdef::xsoar_alerts[]
+// image::cortex_xsoar_config.png[scale=15]
+// endif::xsoar_alerts[]
 
 If you use multi-factor authentication, you must create an exception or app-specific password to allow Console to authenticate to the service.

--- a/docs/en/compute-edition/22-12/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
+++ b/docs/en/compute-edition/22-12/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
@@ -9,8 +9,8 @@ NOTE: The combination of *Rule name* and *App ID* must be unique across In-Line 
 If you have a Swagger or OpenAPI file, click *Import*, and select the file to load.
 +
 If you do not have a Swagger or OpenAPI file, manually define each endpoint by specifying the host, port, and path.
-+
-image::cwp-42473-add-app-policy.png[scale=10]
+// +
+// image::cwp-42473-add-app-policy.png[scale=10]
 
 .. In *Endpoint Setup*, click *Add Endpoint*.
 
@@ -37,8 +37,8 @@ Base path for WAAS to match when applying protections.
 Examples: "/admin", "/" (root path only), "/*", /v2/api", etc.
 ifdef::waas_port[]
 .. Enter *WAAS port (only required for Windows, App-Embedded or when using xref:../waas_advanced_settings.adoc#remote-host["Remote host"] option)* as the external port WAAS listens on. The external port is the TCP port for the App-Embedded Defender to listen on for inbound HTTP traffic.
-+
-image::cwp-42473-add-app-waas-port-windows.png[scale=15]
+// +
+// image::cwp-42473-add-app-waas-port-windows.png[scale=15]
 +
 NOTE: Protecting Linux-based hosts does not require specifying a *`WAAS port`* since WAAS listens on the same port as the protected application. Because Windows has its own internal traffic routing mechanisms, WAAS and the protected application cannot use the same *`App port`*. Consequently, when protecting Windows-based hosts the *`WAAS port`* should be set to the port end-users send requests to, and the *`App port`* should be set to a *different* port on which the protected application will listen and to which WAAS will forward traffic.
 endif::waas_port[]
@@ -64,22 +64,22 @@ WAAS must be able to decrypt and inspect HTTPS traffic to function properly.
 * If your application uses gRPC, set *gRPC* to *On*.
 ifdef::response_headers[]
 .. You can select *Response headers* to add or override HTTP response headers in responses sent from the protected application.
-+
-image::waas_response_headers.png[width=550] 
+// +
+// image::waas_response_headers.png[width=550]
 endif::response_headers[]
 .. Select *Create response header*.
 
 .. To facilitate inspection, after creating all endpoints, click *View TLS settings* in the endpoint setup menu.
 +
 WAAS TLS settings:
-+
-ifndef::waas_oob[]
-image::waas-inline-app-embedded-tls.png[scale=15]
-endif::waas_oob[]
+// +
+// ifndef::waas_oob[]
+// image::waas-inline-app-embedded-tls.png[scale=15]
+// endif::waas_oob[]
 
-ifdef::waas_oob[]
-image::waas-oob-tls.png[scale=15]
-endif::waas_oob[]
+// ifdef::waas_oob[]
+// image::waas-oob-tls.png[scale=15]
+// endif::waas_oob[]
 
 * *Certificate* - Copy and paste your server's certificate and private key into the certificate input box (e.g., `cat server-cert.pem server-key > certs.pem`).
 +
@@ -115,8 +115,8 @@ endif::advanced_tls[]
 . The *Rule Overview* page shows all the WAAS rules created.
 +
 Select a rule to display the *Rule Resources*, and for each application a list of protected endpoints and the protections enabled for each endpoint are displayed.
-+
-image::waas_out_of_band_rule_overview.png[scale=20]
+// +
+// image::waas_out_of_band_rule_overview.png[scale=20]
 
 . Test protected endpoint using the following xref:../waas_app_firewall.adoc#sanity_tests[sanity tests].
 

--- a/docs/en/compute-edition/22-12/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
+++ b/docs/en/compute-edition/22-12/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
@@ -20,13 +20,13 @@ NOTE: The maximum duration in seconds for reading the entire request, including 
 endif::waas_inline_hosts[]
 
 . Choose the rule *Scope* by specifying the resource collection(s) to which it applies.
-+
-image::waas_select_scope.png[scale=20]
+// +
+// image::waas_select_scope.png[scale=20]
 +
 ifdef::waas_containers[]
 Collections define a combination of image names and one or more elements to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_collection.png[scale=20]
+// +
+// image::waas_define_collection.png[scale=20]
 +
 NOTE: Applying a rule to all images using a wild card (`*`) is invalid - instead, only specify your web application images.
 endif::waas_containers[]

--- a/docs/en/compute-edition/22-12/admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
+++ b/docs/en/compute-edition/22-12/admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
@@ -1,6 +1,6 @@
 AWS CloudFormation stack failed to deploy the WAAS agentless resources because Prisma Console is not accessible from AWS.
 
-image::err4-failedcondition-received.png[width=350]
+// image::err4-failedcondition-received.png[width=350]
 
 . Make sure that the IP address of Prisma Console in the VPC configuration is public.
 . Check if the Defender instance has a public IP address.

--- a/docs/en/compute-edition/30/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
+++ b/docs/en/compute-edition/30/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
@@ -5,7 +5,7 @@
 Agentless scans start immediately after onboarding the cloud account.
 By default, agentless scans are performed every 24 hours, but you can change the interval on the *Manage > System > Scan* page under *Scheduling > Agentless*.
 
-image::agentless-interval.png[width=800]
+// image::agentless-interval.png[width=800]
 
 To manually start a scan, complete the following steps.
 
@@ -22,8 +22,8 @@ endif::prisma_cloud[]
 . Click the scan icon on the top right corner of the accounts table.
 
 . Click *Start Agentless scan*.
-+
-image::agentless-start-scan.png[width=400]
+// +
+// image::agentless-start-scan.png[width=400]
 
 . Click the scan icon in the top right corner of the console to view the scan status.
 
@@ -38,13 +38,13 @@ ifdef::prisma_cloud[]
 endif::prisma_cloud[]
 
 .. Click on the *Filter hosts* text bar.
-+
-image::vulnerability-results-filters.png[width=400]
+// +
+// image::vulnerability-results-filters.png[width=400]
 
 .. Select the *Scanned by* filter.
-+
-image::vulnerability-results-scanned-by.png[width=400]
+// +
+// image::vulnerability-results-scanned-by.png[width=400]
 
 .. Select the *Agentless* filter.
-+
-image::vulnerability-results-scanned-by-agentless.png[width=400]
+// +
+// image::vulnerability-results-scanned-by-agentless.png[width=400]

--- a/docs/en/compute-edition/30/admin-guide/alerts/frag-config-rate.adoc
+++ b/docs/en/compute-edition/30/admin-guide/alerts/frag-config-rate.adoc
@@ -13,5 +13,5 @@ All subsequent alerts are sent once per period.
 . In *General settings*, select the default frequency for all alerts.
 +
 You can specify *Second*, *Minute*, *Hour*, *Day*.
-+
-image::frag_configure_alerts.png[scale=15]
+// +
+// image::frag_configure_alerts.png[scale=15]

--- a/docs/en/compute-edition/30/admin-guide/alerts/frag-config-triggers.adoc
+++ b/docs/en/compute-edition/30/admin-guide/alerts/frag-config-triggers.adoc
@@ -8,24 +8,24 @@
 . In *Select triggers*, select the events that should trigger an alert to be sent.
 
 . To specify specific rules that should trigger an alert, deselect *All rules*, and then select any individual rules.
-+
-ifdef::jira_alerts[]
-image::frag_config_jira_triggers.png[scale=15]
-endif::jira_alerts[]
+// +
+// ifdef::jira_alerts[]
+// image::frag_config_jira_triggers.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::servicenow_vr_alerts[]
-+
-image::frag_config_servicenow_vr_triggers.png[scale=15]
-endif::servicenow_vr_alerts[]
+// ifdef::servicenow_vr_alerts[]
+// +
+// image::frag_config_servicenow_vr_triggers.png[scale=15]
+// endif::servicenow_vr_alerts[]
 
-ifdef::cortex_xdr_alerts[]
-+
-image::cortex-xdr-config-triggers.png[scale=15]
-endif::cortex_xdr_alerts[]
+// ifdef::cortex_xdr_alerts[]
+// +
+// image::cortex-xdr-config-triggers.png[scale=15]
+// endif::cortex_xdr_alerts[]
 
-ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
-+
-image::frag_config_triggers.png[scale=15]
-endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// +
+// image::frag_config_triggers.png[scale=15]
+// endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
 
 . Click *Next*.

--- a/docs/en/compute-edition/30/admin-guide/alerts/frag-send-alerts.adoc
+++ b/docs/en/compute-edition/30/admin-guide/alerts/frag-send-alerts.adoc
@@ -8,58 +8,58 @@ Configure Prisma Cloud to integrate with your messaging service and specify the 
 For example, configure the email channel and specify a list of all the email addresses where alerts should be sent.
 Or for JIRA, configure the project where the issue should be created, along with the type of issue, priority, assignee, and so on.
 
-ifdef::email_alerts[]
-image::email-config-1.png[scale=15]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// image::email-config-1.png[scale=15]
+// endif::email_alerts[]
 
-ifdef::webhook_alerts[]
-image::webhook-config-1.png[width=250]
-endif::webhook_alerts[]
+// ifdef::webhook_alerts[]
+// image::webhook-config-1.png[width=250]
+// endif::webhook_alerts[]
 
-ifdef::slack_alerts[]
-image::slack-config-1.png[scale=15]
-endif::slack_alerts[]
+// ifdef::slack_alerts[]
+// image::slack-config-1.png[scale=15]
+// endif::slack_alerts[]
 
 *(2) Alert triggers -- Which events should trigger an alert to be sent?*
 Specify which of the rules that make up your overall policy should trigger alerts.
 
-ifdef::aws_security_hub[]
-image::aws_security_hub_config.png[scale=15]
-endif::aws_security_hub[]
+// ifdef::aws_security_hub[]
+// image::aws_security_hub_config.png[scale=15]
+// endif::aws_security_hub[]
 
-ifdef::email_alerts[]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// endif::email_alerts[]
 
-ifdef::google_cloud_pub_sub[]
-image::google_cloud_pub_sub_config.png[scale=15]
-endif::google_cloud_pub_sub[]
+// ifdef::google_cloud_pub_sub[]
+// image::google_cloud_pub_sub_config.png[scale=15]
+// endif::google_cloud_pub_sub[]
 
-ifdef::google_cloud_scc[]
-image::google_cloud_scc_config.png[scale=15]
-endif::google_cloud_scc[]
+// ifdef::google_cloud_scc[]
+// image::google_cloud_scc_config.png[scale=15]
+// endif::google_cloud_scc[]
 
-ifdef::ibm_cloud_security_advisor[]
-image::ibm_cloud_security_advisor_config.png[scale=15]
-endif::ibm_cloud_security_advisor[]
+// ifdef::ibm_cloud_security_advisor[]
+// image::ibm_cloud_security_advisor_config.png[scale=15]
+// endif::ibm_cloud_security_advisor[]
 
-ifdef::jira_alerts[]
-image::jira_config.png[scale=15]
-endif::jira_alerts[]
+// ifdef::jira_alerts[]
+// image::jira_config.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::pagerduty_alerts[]
-image::pagerduty_config.png[scale=15]
-endif::pagerduty_alerts[]
+// ifdef::pagerduty_alerts[]
+// image::pagerduty_config.png[scale=15]
+// endif::pagerduty_alerts[]
 
-ifdef::slack_alerts,webhook_alerts[]
-image::slack-config-2.png[width=250]
-endif::slack_alerts,webhook_alerts[]
+// ifdef::slack_alerts,webhook_alerts[]
+// image::slack-config-2.png[width=250]
+// endif::slack_alerts,webhook_alerts[]
 
-ifdef::xdr_alerts[]
-image::cortex_xdr_config.png[scale=15]
-endif::xdr_alerts[]
+// ifdef::xdr_alerts[]
+// image::cortex_xdr_config.png[scale=15]
+// endif::xdr_alerts[]
 
-ifdef::xsoar_alerts[]
-image::cortex_xsoar_config.png[scale=15]
-endif::xsoar_alerts[]
+// ifdef::xsoar_alerts[]
+// image::cortex_xsoar_config.png[scale=15]
+// endif::xsoar_alerts[]
 
 If you use multi-factor authentication, you must create an exception or app-specific password to allow Console to authenticate to the service.

--- a/docs/en/compute-edition/30/admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
+++ b/docs/en/compute-edition/30/admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
@@ -132,12 +132,12 @@ Confirm the installation was successful.
 
 [.procedure]
 . In Prisma Cloud Console, go to *Compute > Manage > Defenders > Manage* to see a list of deployed Defenders.
-+
-image::install_openshift_tl_defenders.png[width=800]
+// +
+// image::install_openshift_tl_defenders.png[width=800]
 
 . In the OpenShift Web Console, go to the Prisma Cloud project's monitoring window to see which pods are running.
-+
-image::install_openshift_ose_defenders.png[width=800]
+// +
+// image::install_openshift_ose_defenders.png[width=800]
 
 . Use the OpenShift CLI to see the DaemonSet pod count.
 

--- a/docs/en/compute-edition/30/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
+++ b/docs/en/compute-edition/30/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
@@ -38,8 +38,8 @@ Base path for WAAS to match when applying protections.
 Examples: "/admin", "/" (root path only), "/*", /v2/api", etc.
 ifdef::waas_port[]
 .. Enter *WAAS port (only required for Windows, App-Embedded or when using xref:../waas-advanced-settings.adoc#remote-host["Remote host"] option)* as the external port WAAS listens on. The external port is the TCP port for the App-Embedded Defender to listen on for inbound HTTP traffic.
-+
-image::cwp-42473-add-app-waas-port-windows.png[scale=15]
+// +
+// image::cwp-42473-add-app-waas-port-windows.png[scale=15]
 endif::waas_port[]
 ifdef::waas_hosts[]
 +
@@ -75,14 +75,14 @@ endif::response_headers[]
 .. To facilitate inspection, after creating all endpoints, click *View TLS settings* in the endpoint setup menu.
 +
 WAAS TLS settings:
-+
-ifndef::waas_oob[]
-image::waas-inline-app-embedded-tls.png[scale=15]
-endif::waas_oob[]
+// +
+// ifndef::waas_oob[]
+// image::waas-inline-app-embedded-tls.png[scale=15]
+// endif::waas_oob[]
 
-ifdef::waas_oob[]
-image::waas-oob-tls.png[scale=15]
-endif::waas_oob[]
+// ifdef::waas_oob[]
+// image::waas-oob-tls.png[scale=15]
+// endif::waas_oob[]
 
 * *Certificate* - Copy and paste your server's certificate and private key into the certificate input box (e.g., `cat server-cert.pem server-key > certs.pem`).
 +

--- a/docs/en/compute-edition/30/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
+++ b/docs/en/compute-edition/30/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
@@ -20,24 +20,24 @@ NOTE: The maximum duration in seconds for reading the entire request, including 
 endif::waas_inline_hosts[]
 
 . Choose the rule *Scope* by specifying the resource collection(s) to which it applies.
-+
-image::waas_select_scope.png[scale=20]
+// +
+// image::waas_select_scope.png[scale=20]
 +
 ifdef::waas_containers[]
 Collections define a combination of image names and one or more elements to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_collection.png[width=250]
+// +
+// image::waas_define_collection.png[width=250]
 +
 NOTE: Applying a rule to all images using a wild card (`*`) is invalid - instead, only specify your web application images.
 endif::waas_containers[]
 
 ifdef::waas_hosts[]
 Collections define a combination of hosts to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_host_collection.png[width=250]
-ifdef::waas_oob_hosts[]
-image::waas_define_collection_oob_hosts.png[width=250]
-endif::waas_oob_hosts[]
+// +
+// image::waas_define_host_collection.png[width=250]
+// ifdef::waas_oob_hosts[]
+// image::waas_define_collection_oob_hosts.png[width=250]
+// endif::waas_oob_hosts[]
 +
 NOTE: Applying a rule to all hosts/images using a wild card (`*`) is invalid and a waste of resources.
 WAAS only needs to be applied to hosts that run applications that transmit and receive HTTP/HTTPS traffic.

--- a/docs/en/compute-edition/30/admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
+++ b/docs/en/compute-edition/30/admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
@@ -1,6 +1,6 @@
 AWS CloudFormation stack failed to deploy the WAAS agentless resources because Prisma Console is not accessible from AWS.
 
-image::err4-failedcondition-received.png[width=350]
+// image::err4-failedcondition-received.png[width=350]
 
 . Make sure that the IP address of Prisma Console in the VPC configuration is public.
 . Check if the Defender instance has a public IP address.

--- a/docs/en/compute-edition/31/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
+++ b/docs/en/compute-edition/31/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
@@ -5,7 +5,7 @@
 Agentless scans start immediately after onboarding the cloud account.
 By default, agentless scans are performed every 24 hours, but you can change the interval on the *Manage > System > Scan* page under *Scheduling > Agentless*.
 
-image::agentless-interval.png[width=800]
+// image::agentless-interval.png[width=800]
 
 To manually start a scan, complete the following steps.
 
@@ -22,8 +22,8 @@ endif::prisma_cloud[]
 . Click the scan icon on the top right corner of the accounts table.
 
 . Click *Start Agentless scan*.
-+
-image::agentless-start-scan.png[width=400]
+// +
+// image::agentless-start-scan.png[width=400]
 
 . Click the scan icon in the top right corner of the console to view the scan status.
 
@@ -38,13 +38,13 @@ ifdef::prisma_cloud[]
 endif::prisma_cloud[]
 
 .. Click on the *Filter hosts* text bar.
-+
-image::vulnerability-results-filters.png[width=400]
+// +
+// image::vulnerability-results-filters.png[width=400]
 
 .. Select the *Scanned by* filter.
-+
-image::vulnerability-results-scanned-by.png[width=400]
+// +
+// image::vulnerability-results-scanned-by.png[width=400]
 
 .. Select the *Agentless* filter.
-+
-image::vulnerability-results-scanned-by-agentless.png[width=400]
+// +
+// image::vulnerability-results-scanned-by-agentless.png[width=400]

--- a/docs/en/compute-edition/31/admin-guide/alerts/frag-config-triggers.adoc
+++ b/docs/en/compute-edition/31/admin-guide/alerts/frag-config-triggers.adoc
@@ -8,24 +8,24 @@
 . In *Select triggers*, select the events that should trigger an alert to be sent.
 
 . To specify specific rules that should trigger an alert, deselect *All rules*, and then select any individual rules.
-+
-ifdef::jira_alerts[]
-image::frag_config_jira_triggers.png[scale=15]
-endif::jira_alerts[]
+// +
+// ifdef::jira_alerts[]
+// image::frag_config_jira_triggers.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::servicenow_vr_alerts[]
-+
-image::frag_config_servicenow_vr_triggers.png[scale=15]
-endif::servicenow_vr_alerts[]
+// ifdef::servicenow_vr_alerts[]
+// +
+// image::frag_config_servicenow_vr_triggers.png[scale=15]
+// endif::servicenow_vr_alerts[]
 
-ifdef::cortex_xdr_alerts[]
-+
-image::cortex-xdr-config-triggers.png[scale=15]
-endif::cortex_xdr_alerts[]
+// ifdef::cortex_xdr_alerts[]
+// +
+// image::cortex-xdr-config-triggers.png[scale=15]
+// endif::cortex_xdr_alerts[]
 
-ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
-+
-image::frag_config_triggers.png[scale=15]
-endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// +
+// image::frag_config_triggers.png[scale=15]
+// endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
 
 . Click *Next*.

--- a/docs/en/compute-edition/31/admin-guide/alerts/frag-send-alerts.adoc
+++ b/docs/en/compute-edition/31/admin-guide/alerts/frag-send-alerts.adoc
@@ -8,58 +8,58 @@ Configure Prisma Cloud to integrate with your messaging service and specify the 
 For example, configure the email channel and specify a list of all the email addresses where alerts should be sent.
 Or for JIRA, configure the project where the issue should be created, along with the type of issue, priority, assignee, and so on.
 
-ifdef::email_alerts[]
-image::email-config-1.png[scale=15]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// image::email-config-1.png[scale=15]
+// endif::email_alerts[]
 
-ifdef::webhook_alerts[]
-image::webhook-config-1.png[width=250]
-endif::webhook_alerts[]
+// ifdef::webhook_alerts[]
+// image::webhook-config-1.png[width=250]
+// endif::webhook_alerts[]
 
-ifdef::slack_alerts[]
-image::slack-config-1.png[scale=15]
-endif::slack_alerts[]
+// ifdef::slack_alerts[]
+// image::slack-config-1.png[scale=15]
+// endif::slack_alerts[]
 
 *(2) Alert triggers -- Which events should trigger an alert to be sent?*
 Specify which of the rules that make up your overall policy should trigger alerts.
 
-ifdef::aws_security_hub[]
-image::aws_security_hub_config.png[scale=15]
-endif::aws_security_hub[]
+// ifdef::aws_security_hub[]
+// image::aws_security_hub_config.png[scale=15]
+// endif::aws_security_hub[]
 
-ifdef::email_alerts[]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// endif::email_alerts[]
 
-ifdef::google_cloud_pub_sub[]
-image::google_cloud_pub_sub_config.png[scale=15]
-endif::google_cloud_pub_sub[]
+// ifdef::google_cloud_pub_sub[]
+// image::google_cloud_pub_sub_config.png[scale=15]
+// endif::google_cloud_pub_sub[]
 
-ifdef::google_cloud_scc[]
-image::google_cloud_scc_config.png[scale=15]
-endif::google_cloud_scc[]
+// ifdef::google_cloud_scc[]
+// image::google_cloud_scc_config.png[scale=15]
+// endif::google_cloud_scc[]
 
-ifdef::ibm_cloud_security_advisor[]
-image::ibm_cloud_security_advisor_config.png[scale=15]
-endif::ibm_cloud_security_advisor[]
+// ifdef::ibm_cloud_security_advisor[]
+// image::ibm_cloud_security_advisor_config.png[scale=15]
+// endif::ibm_cloud_security_advisor[]
 
-ifdef::jira_alerts[]
-image::jira_config.png[scale=15]
-endif::jira_alerts[]
+// ifdef::jira_alerts[]
+// image::jira_config.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::pagerduty_alerts[]
-image::pagerduty_config.png[scale=15]
-endif::pagerduty_alerts[]
+// ifdef::pagerduty_alerts[]
+// image::pagerduty_config.png[scale=15]
+// endif::pagerduty_alerts[]
 
-ifdef::slack_alerts,webhook_alerts[]
-image::slack-config-2.png[width=250]
-endif::slack_alerts,webhook_alerts[]
+// ifdef::slack_alerts,webhook_alerts[]
+// image::slack-config-2.png[width=250]
+// endif::slack_alerts,webhook_alerts[]
 
-ifdef::xdr_alerts[]
-image::cortex_xdr_config.png[scale=15]
-endif::xdr_alerts[]
+// ifdef::xdr_alerts[]
+// image::cortex_xdr_config.png[scale=15]
+// endif::xdr_alerts[]
 
-ifdef::xsoar_alerts[]
-image::cortex_xsoar_config.png[scale=15]
-endif::xsoar_alerts[]
+// ifdef::xsoar_alerts[]
+// image::cortex_xsoar_config.png[scale=15]
+// endif::xsoar_alerts[]
 
 If you use multi-factor authentication, you must create an exception or app-specific password to allow Console to authenticate to the service.

--- a/docs/en/compute-edition/31/admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
+++ b/docs/en/compute-edition/31/admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
@@ -132,12 +132,12 @@ Confirm the installation was successful.
 
 [.procedure]
 . In Prisma Cloud Console, go to *Compute > Manage > Defenders > Manage* to see a list of deployed Defenders.
-+
-image::install_openshift_tl_defenders.png[width=800]
+// +
+// image::install_openshift_tl_defenders.png[width=800]
 
 . In the OpenShift Web Console, go to the Prisma Cloud project's monitoring window to see which pods are running.
-+
-image::install_openshift_ose_defenders.png[width=800]
+// +
+// image::install_openshift_ose_defenders.png[width=800]
 
 . Use the OpenShift CLI to see the DaemonSet pod count.
 

--- a/docs/en/compute-edition/31/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
+++ b/docs/en/compute-edition/31/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
@@ -38,8 +38,8 @@ Base path for WAAS to match when applying protections.
 Examples: "/admin", "/" (root path only), "/*", /v2/api", etc.
 ifdef::waas_port[]
 .. Enter *WAAS port (only required for Windows, App-Embedded or when using xref:../waas-advanced-settings.adoc#remote-host["Remote host"] option)* as the external port WAAS listens on. The external port is the TCP port for the App-Embedded Defender to listen on for inbound HTTP traffic.
-+
-image::cwp-42473-add-app-waas-port-windows.png[scale=15]
+// +
+// image::cwp-42473-add-app-waas-port-windows.png[scale=15]
 endif::waas_port[]
 ifdef::waas_hosts[]
 +
@@ -69,22 +69,22 @@ WAAS must be able to decrypt and inspect HTTPS traffic to function properly.
 endif::waas_oob[]
 ifdef::response_headers[]
 .. You can select *Response headers* to add or override HTTP response headers in responses sent from the protected application.
-+
-image::waas_response_headers.png[width=550] 
+// +
+// image::waas_response_headers.png[width=550]
 endif::response_headers[]
 .. Select *Create response header*.
 
 .. To facilitate inspection, after creating all endpoints, click *View TLS settings* in the endpoint setup menu.
 +
 WAAS TLS settings:
-+
-ifndef::waas_oob[]
-image::waas-inline-app-embedded-tls.png[scale=15]
-endif::waas_oob[]
+// +
+// ifndef::waas_oob[]
+// image::waas-inline-app-embedded-tls.png[scale=15]
+// endif::waas_oob[]
 
-ifdef::waas_oob[]
-image::waas-oob-tls.png[scale=15]
-endif::waas_oob[]
+// ifdef::waas_oob[]
+// image::waas-oob-tls.png[scale=15]
+// endif::waas_oob[]
 
 * *Certificate* - Copy and paste your server's certificate and private key into the certificate input box (e.g., `cat server-cert.pem server-key > certs.pem`).
 +

--- a/docs/en/compute-edition/31/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
+++ b/docs/en/compute-edition/31/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
@@ -20,24 +20,24 @@ NOTE: The maximum duration in seconds for reading the entire request, including 
 endif::waas_inline_hosts[]
 
 . Choose the rule *Scope* by specifying the resource collection(s) to which it applies.
-+
-image::waas_select_scope.png[scale=20]
+// +
+// image::waas_select_scope.png[scale=20]
 +
 ifdef::waas_containers[]
 Collections define a combination of image names and one or more elements to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_collection.png[width=250]
+// +
+// image::waas_define_collection.png[width=250]
 +
 NOTE: Applying a rule to all images using a wild card (`*`) is invalid - instead, only specify your web application images.
 endif::waas_containers[]
 
 ifdef::waas_hosts[]
 Collections define a combination of hosts to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_host_collection.png[width=250]
-ifdef::waas_oob_hosts[]
-image::waas_define_collection_oob_hosts.png[width=250]
-endif::waas_oob_hosts[]
+// +
+// image::waas_define_host_collection.png[width=250]
+// ifdef::waas_oob_hosts[]
+// image::waas_define_collection_oob_hosts.png[width=250]
+// endif::waas_oob_hosts[]
 +
 NOTE: Applying a rule to all hosts/images using a wild card (`*`) is invalid and a waste of resources.
 WAAS only needs to be applied to hosts that run applications that transmit and receive HTTP/HTTPS traffic.

--- a/docs/en/compute-edition/32/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
+++ b/docs/en/compute-edition/32/admin-guide/agentless-scanning/onboard-accounts/frag-start-agentless-scan.adoc
@@ -5,7 +5,7 @@
 Agentless scans start immediately after onboarding the cloud account.
 By default, agentless scans are performed every 24 hours, but you can change the interval on the *Manage > System > Scan* page under *Scheduling > Agentless*.
 
-image::agentless-interval.png[width=800]
+// image::agentless-interval.png[width=800]
 
 To manually start a scan, complete the following steps.
 
@@ -22,8 +22,8 @@ endif::prisma_cloud[]
 . Click the scan icon on the top right corner of the accounts table.
 
 . Click *Start Agentless scan*.
-+
-image::agentless-start-scan.png[width=400]
+// +
+// image::agentless-start-scan.png[width=400]
 
 . Click the scan icon in the top right corner of the console to view the scan status.
 
@@ -38,13 +38,13 @@ ifdef::prisma_cloud[]
 endif::prisma_cloud[]
 
 .. Click on the *Filter hosts* text bar.
-+
-image::vulnerability-results-filters.png[width=400]
+// +
+// image::vulnerability-results-filters.png[width=400]
 
 .. Select the *Scanned by* filter.
-+
-image::vulnerability-results-scanned-by.png[width=400]
+// +
+// image::vulnerability-results-scanned-by.png[width=400]
 
 .. Select the *Agentless* filter.
-+
-image::vulnerability-results-scanned-by-agentless.png[width=400]
+// +
+// image::vulnerability-results-scanned-by-agentless.png[width=400]

--- a/docs/en/compute-edition/32/admin-guide/alerts/frag-config-triggers.adoc
+++ b/docs/en/compute-edition/32/admin-guide/alerts/frag-config-triggers.adoc
@@ -8,24 +8,24 @@
 . In *Select triggers*, select the events that should trigger an alert to be sent.
 
 . To specify specific rules that should trigger an alert, deselect *All rules*, and then select any individual rules.
-+
-ifdef::jira_alerts[]
-image::frag_config_jira_triggers.png[scale=15]
-endif::jira_alerts[]
+// +
+// ifdef::jira_alerts[]
+// image::frag_config_jira_triggers.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::servicenow_vr_alerts[]
-+
-image::frag_config_servicenow_vr_triggers.png[scale=15]
-endif::servicenow_vr_alerts[]
+// ifdef::servicenow_vr_alerts[]
+// +
+// image::frag_config_servicenow_vr_triggers.png[scale=15]
+// endif::servicenow_vr_alerts[]
 
-ifdef::cortex_xdr_alerts[]
-+
-image::cortex-xdr-config-triggers.png[scale=15]
-endif::cortex_xdr_alerts[]
+// ifdef::cortex_xdr_alerts[]
+// +
+// image::cortex-xdr-config-triggers.png[scale=15]
+// endif::cortex_xdr_alerts[]
 
-ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
-+
-image::frag_config_triggers.png[scale=15]
-endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// ifndef::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
+// +
+// image::frag_config_triggers.png[scale=15]
+// endif::jira_alerts,servicenow_vr_alerts,cortex_xdr_alerts[]
 
 . Click *Next*.

--- a/docs/en/compute-edition/32/admin-guide/alerts/frag-send-alerts.adoc
+++ b/docs/en/compute-edition/32/admin-guide/alerts/frag-send-alerts.adoc
@@ -8,58 +8,58 @@ Configure Prisma Cloud to integrate with your messaging service and specify the 
 For example, configure the email channel and specify a list of all the email addresses where alerts should be sent.
 Or for JIRA, configure the project where the issue should be created, along with the type of issue, priority, assignee, and so on.
 
-ifdef::email_alerts[]
-image::email-config-1.png[scale=15]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// image::email-config-1.png[scale=15]
+// endif::email_alerts[]
 
-ifdef::webhook_alerts[]
-image::webhook-config-1.png[width=250]
-endif::webhook_alerts[]
+// ifdef::webhook_alerts[]
+// image::webhook-config-1.png[width=250]
+// endif::webhook_alerts[]
 
-ifdef::slack_alerts[]
-image::slack-config-1.png[scale=15]
-endif::slack_alerts[]
+// ifdef::slack_alerts[]
+// image::slack-config-1.png[scale=15]
+// endif::slack_alerts[]
 
 *(2) Alert triggers -- Which events should trigger an alert to be sent?*
 Specify which of the rules that make up your overall policy should trigger alerts.
 
-ifdef::aws_security_hub[]
-image::aws_security_hub_config.png[scale=15]
-endif::aws_security_hub[]
+// ifdef::aws_security_hub[]
+// image::aws_security_hub_config.png[scale=15]
+// endif::aws_security_hub[]
 
-ifdef::email_alerts[]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// endif::email_alerts[]
 
-ifdef::google_cloud_pub_sub[]
-image::google_cloud_pub_sub_config.png[scale=15]
-endif::google_cloud_pub_sub[]
+// ifdef::google_cloud_pub_sub[]
+// image::google_cloud_pub_sub_config.png[scale=15]
+// endif::google_cloud_pub_sub[]
 
-ifdef::google_cloud_scc[]
-image::google_cloud_scc_config.png[scale=15]
-endif::google_cloud_scc[]
+// ifdef::google_cloud_scc[]
+// image::google_cloud_scc_config.png[scale=15]
+// endif::google_cloud_scc[]
 
-ifdef::ibm_cloud_security_advisor[]
-image::ibm_cloud_security_advisor_config.png[scale=15]
-endif::ibm_cloud_security_advisor[]
+// ifdef::ibm_cloud_security_advisor[]
+// image::ibm_cloud_security_advisor_config.png[scale=15]
+// endif::ibm_cloud_security_advisor[]
 
-ifdef::jira_alerts[]
-image::jira_config.png[scale=15]
-endif::jira_alerts[]
+// ifdef::jira_alerts[]
+// image::jira_config.png[scale=15]
+// endif::jira_alerts[]
 
-ifdef::pagerduty_alerts[]
-image::pagerduty_config.png[scale=15]
-endif::pagerduty_alerts[]
+// ifdef::pagerduty_alerts[]
+// image::pagerduty_config.png[scale=15]
+// endif::pagerduty_alerts[]
 
-ifdef::slack_alerts,webhook_alerts[]
-image::slack-config-2.png[width=250]
-endif::slack_alerts,webhook_alerts[]
+// ifdef::slack_alerts,webhook_alerts[]
+// image::slack-config-2.png[width=250]
+// endif::slack_alerts,webhook_alerts[]
 
-ifdef::xdr_alerts[]
-image::cortex_xdr_config.png[scale=15]
-endif::xdr_alerts[]
+// ifdef::xdr_alerts[]
+// image::cortex_xdr_config.png[scale=15]
+// endif::xdr_alerts[]
 
-ifdef::xsoar_alerts[]
-image::cortex_xsoar_config.png[scale=15]
-endif::xsoar_alerts[]
+// ifdef::xsoar_alerts[]
+// image::cortex_xsoar_config.png[scale=15]
+// endif::xsoar_alerts[]
 
 If you use multi-factor authentication, you must create an exception or app-specific password to allow Console to authenticate to the service.

--- a/docs/en/compute-edition/32/admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
+++ b/docs/en/compute-edition/32/admin-guide/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
@@ -132,12 +132,12 @@ Confirm the installation was successful.
 
 [.procedure]
 . In Prisma Cloud Console, go to *Compute > Manage > Defenders > Manage* to see a list of deployed Defenders.
-+
-image::install_openshift_tl_defenders.png[width=800]
+// +
+// image::install_openshift_tl_defenders.png[width=800]
 
 . In the OpenShift Web Console, go to the Prisma Cloud project's monitoring window to see which pods are running.
-+
-image::install_openshift_ose_defenders.png[width=800]
+// +
+// image::install_openshift_ose_defenders.png[width=800]
 
 . Use the OpenShift CLI to see the DaemonSet pod count.
 

--- a/docs/en/compute-edition/32/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
+++ b/docs/en/compute-edition/32/admin-guide/waas/deploy-waas/fragments/add-app-policy.adoc
@@ -38,8 +38,8 @@ Base path for WAAS to match when applying protections.
 Examples: "/admin", "/" (root path only), "/*", /v2/api", etc.
 ifdef::waas_port[]
 .. Enter *WAAS port (only required for Windows, App-Embedded or when using xref:../waas-advanced-settings.adoc#remote-host["Remote host"] option)* as the external port WAAS listens on. The external port is the TCP port for the App-Embedded Defender to listen on for inbound HTTP traffic.
-+
-image::cwp-42473-add-app-waas-port-windows.png[scale=15]
+// +
+// image::cwp-42473-add-app-waas-port-windows.png[scale=15]
 endif::waas_port[]
 ifdef::waas_hosts[]
 +
@@ -69,22 +69,22 @@ WAAS must be able to decrypt and inspect HTTPS traffic to function properly.
 endif::waas_oob[]
 ifdef::response_headers[]
 .. You can select *Response headers* to add or override HTTP response headers in responses sent from the protected application.
-+
-image::waas_response_headers.png[width=550] 
+// +
+// image::waas_response_headers.png[width=550]
 endif::response_headers[]
 .. Select *Create response header*.
 
 .. To facilitate inspection, after creating all endpoints, click *View TLS settings* in the endpoint setup menu.
 +
 WAAS TLS settings:
-+
-ifndef::waas_oob[]
-image::waas-inline-app-embedded-tls.png[scale=15]
-endif::waas_oob[]
+// +
+// ifndef::waas_oob[]
+// image::waas-inline-app-embedded-tls.png[scale=15]
+// endif::waas_oob[]
 
-ifdef::waas_oob[]
-image::waas-oob-tls.png[scale=15]
-endif::waas_oob[]
+// ifdef::waas_oob[]
+// image::waas-oob-tls.png[scale=15]
+// endif::waas_oob[]
 
 * *Certificate* - Copy and paste your server's certificate and private key into the certificate input box (e.g., `cat server-cert.pem server-key > certs.pem`).
 +

--- a/docs/en/compute-edition/32/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
+++ b/docs/en/compute-edition/32/admin-guide/waas/deploy-waas/fragments/create-waas-rule.adoc
@@ -20,24 +20,24 @@ NOTE: The maximum duration in seconds for reading the entire request, including 
 endif::waas_inline_hosts[]
 
 . Choose the rule *Scope* by specifying the resource collection(s) to which it applies.
-+
-image::waas_select_scope.png[scale=20]
+// +
+// image::waas_select_scope.png[scale=20]
 +
 ifdef::waas_containers[]
 Collections define a combination of image names and one or more elements to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_collection.png[width=250]
+// +
+// image::waas_define_collection.png[width=250]
 +
 NOTE: Applying a rule to all images using a wild card (`*`) is invalid - instead, only specify your web application images.
 endif::waas_containers[]
 
 ifdef::waas_hosts[]
 Collections define a combination of hosts to which WAAS should attach itself to protect the web application:
-+
-image::waas_define_host_collection.png[width=250]
-ifdef::waas_oob_hosts[]
-image::waas_define_collection_oob_hosts.png[width=250]
-endif::waas_oob_hosts[]
+// +
+// image::waas_define_host_collection.png[width=250]
+// ifdef::waas_oob_hosts[]
+// image::waas_define_collection_oob_hosts.png[width=250]
+// endif::waas_oob_hosts[]
 +
 NOTE: Applying a rule to all hosts/images using a wild card (`*`) is invalid and a waste of resources.
 WAAS only needs to be applied to hosts that run applications that transmit and receive HTTP/HTTPS traffic.

--- a/docs/en/compute-edition/32/admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
+++ b/docs/en/compute-edition/32/admin-guide/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
@@ -1,6 +1,6 @@
 AWS CloudFormation stack failed to deploy the WAAS agentless resources because Prisma Console is not accessible from AWS.
 
-image::err4-failedcondition-received.png[width=350]
+// image::err4-failedcondition-received.png[width=350]
 
 . Make sure that the IP address of Prisma Console in the VPC configuration is public.
 . Check if the Defender instance has a public IP address.

--- a/docs/en/enterprise-edition/content-collections/runtime-security/agentless-scanning/configure-accounts/frag-start-agentless-scan.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/agentless-scanning/configure-accounts/frag-start-agentless-scan.adoc
@@ -5,7 +5,7 @@
 Agentless scans start immediately after onboarding the cloud account.
 By default, agentless scans are performed every 24 hours, but you can change the interval on the *Manage > System > Scan* page under *Scheduling > Agentless*.
 
-image::runtime-security/agentless-interval.png[width=800]
+// image::runtime-security/agentless-interval.png[width=800]
 
 To manually start a scan, complete the following steps.
 
@@ -16,8 +16,8 @@ To manually start a scan, complete the following steps.
 . Click the scan icon on the top right corner of the accounts table.
 
 . Click *Start Agentless scan*.
-+
-image::runtime-security/agentless-start-scan.png[width=400]
+// +
+// image::runtime-security/agentless-start-scan.png[width=400]
 
 . Click the scan icon in the top right corner of the console to view the scan status.
 
@@ -26,13 +26,13 @@ image::runtime-security/agentless-start-scan.png[width=400]
 .. Go to *Runtime Security > Monitor > Vulnerabilities > Hosts* or *Runtime Security > Monitor > Vulnerabilities > Images*.
 
 .. Click on the *Filter hosts* text bar.
-+
-image::runtime-security/vulnerability-results-filters.png[width=400]
+// +
+// image::runtime-security/vulnerability-results-filters.png[width=400]
 
 .. Select the *Scanned by* filter.
-+
-image::runtime-security/vulnerability-results-scanned-by.png[width=400]
+// +
+// image::runtime-security/vulnerability-results-scanned-by.png[width=400]
 
 .. Select the *Agentless* filter.
-+
-image::runtime-security/vulnerability-results-scanned-by-agentless.png[width=400]
+// +
+// image::runtime-security/vulnerability-results-scanned-by-agentless.png[width=400]

--- a/docs/en/enterprise-edition/content-collections/runtime-security/alerts/frag-config-rate.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/alerts/frag-config-rate.adoc
@@ -13,5 +13,5 @@ All subsequent alerts are sent once per period.
 . In *General settings*, select the default frequency for all alerts.
 +
 You can specify *Second*, *Minute*, *Hour*, *Day*.
-+
-image::runtime-security/frag-configure-alerts.png[]
+// +
+// image::runtime-security/frag-configure-alerts.png[]

--- a/docs/en/enterprise-edition/content-collections/runtime-security/alerts/frag-config-triggers.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/alerts/frag-config-triggers.adoc
@@ -9,9 +9,9 @@
 
 . To specify specific rules that should trigger an alert, deselect *All rules*, and then select any individual rules.
 
-ifdef::cortex_xdr_alerts[]
-+
-image::runtime-security/cortex-xdr-config-triggers.png[]
-endif::cortex_xdr_alerts[]
+// ifdef::cortex_xdr_alerts[]
+// +
+// image::runtime-security/cortex-xdr-config-triggers.png[]
+// endif::cortex_xdr_alerts[]
 
 . Click *Next*.

--- a/docs/en/enterprise-edition/content-collections/runtime-security/alerts/frag-send-alerts.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/alerts/frag-send-alerts.adoc
@@ -8,27 +8,27 @@ Configure Prisma Cloud to integrate with your messaging service and specify the 
 For example, configure the email channel and specify a list of all the email addresses where alerts should be sent.
 Or for JIRA, configure the project where the issue should be created, along with the type of issue, priority, assignee, and so on.
 
-ifdef::email_alerts[]
-image::runtime-security/email-config-1.png[]
-endif::email_alerts[]
+// ifdef::email_alerts[]
+// image::runtime-security/email-config-1.png[]
+// endif::email_alerts[]
 
 *(2) Alert triggers -- Which events should trigger an alert to be sent?*
 Specify which of the rules that make up your overall policy should trigger alerts.
 
-ifdef::google_cloud_pub_sub[]
-image::runtime-security/google-cloud-pub-sub-config.png[]
-endif::google_cloud_pub_sub[]
+// ifdef::google_cloud_pub_sub[]
+// image::runtime-security/google-cloud-pub-sub-config.png[]
+// endif::google_cloud_pub_sub[]
 
-ifdef::ibm_cloud_security_advisor[]
-image::runtime-security/ibm-cloud-security-advisor-config.png[]
-endif::ibm_cloud_security_advisor[]
+// ifdef::ibm_cloud_security_advisor[]
+// image::runtime-security/ibm-cloud-security-advisor-config.png[]
+// endif::ibm_cloud_security_advisor[]
 
-ifdef::pagerduty_alerts[]
-image::runtime-security/pagerduty-config.png[]
-endif::pagerduty_alerts[]
+// ifdef::pagerduty_alerts[]
+// image::runtime-security/pagerduty-config.png[]
+// endif::pagerduty_alerts[]
 
-ifdef::xdr_alerts[]
-image::runtime-security/cortex-xdr-config.png[]
-endif::xdr_alerts[]
+// ifdef::xdr_alerts[]
+// image::runtime-security/cortex-xdr-config.png[]
+// endif::xdr_alerts[]
 
 If you use multi-factor authentication, you must create an exception or app-specific password to allow Console to authenticate to the service.

--- a/docs/en/enterprise-edition/content-collections/runtime-security/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/install/fragments/install-defender-twistcli-export-oc-3-11.adoc
@@ -132,12 +132,12 @@ Confirm the installation was successful.
 
 [.procedure]
 . In Prisma Cloud Console, go to *Runtime Security > Manage > Defenders > Manage* to see a list of deployed Defenders.
-+
-image::runtime-security/install-openshift-tl-defenders.png[width=800]
+// +
+// image::runtime-security/install-openshift-tl-defenders.png[width=800]
 
 . In the OpenShift Web Console, go to the Prisma Cloud project's monitoring window to see which pods are running.
-+
-image::runtime-security/install-openshift-ose-defenders.png[width=800]
+// +
+// image::runtime-security/install-openshift-ose-defenders.png[width=800]
 
 . Use the OpenShift CLI to see the DaemonSet pod count.
 

--- a/docs/en/enterprise-edition/content-collections/runtime-security/waas/deploy-waas/fragments/add-app-policy.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/waas/deploy-waas/fragments/add-app-policy.adoc
@@ -38,8 +38,8 @@ Base path for WAAS to match when applying protections.
 Examples: "/admin", "/" (root path only), "/*", /v2/api", etc.
 ifdef::waas_port[]
 .. Enter *WAAS port (only required for Windows, App-Embedded or when using xref:../waas-advanced-settings.adoc#remote-host["Remote host"] option)* as the external port WAAS listens on. The external port is the TCP port for the App-Embedded Defender to listen on for inbound HTTP traffic.
-+
-image::runtime-security/cwp-42473-add-app-waas-port-windows.png[]
+// +
+// image::runtime-security/cwp-42473-add-app-waas-port-windows.png[]
 endif::waas_port[]
 ifdef::waas_hosts[]
 +
@@ -69,22 +69,22 @@ WAAS must be able to decrypt and inspect HTTPS traffic to function properly.
 endif::waas_oob[]
 ifdef::response_headers[]
 .. You can select *Response headers* to add or override HTTP response headers in responses sent from the protected application.
-+
-image::runtime-security/waas-response-headers.png[]
+// +
+// image::runtime-security/waas-response-headers.png[]
 endif::response_headers[]
 .. Select *Create response header*.
 
 .. To facilitate inspection, after creating all endpoints, click *View TLS settings* in the endpoint setup menu.
-+
-WAAS TLS settings:
-+
-ifndef::waas_oob[]
-image::runtime-security/waas-inline-app-embedded-tls.png[]
-endif::waas_oob[]
+// +
+// WAAS TLS settings:
+// +
+// ifndef::waas_oob[]
+// image::runtime-security/waas-inline-app-embedded-tls.png[]
+// endif::waas_oob[]
 
-ifdef::waas_oob[]
-image::runtime-security/waas-oob-tls.png[]
-endif::waas_oob[]
+// ifdef::waas_oob[]
+// image::runtime-security/waas-oob-tls.png[]
+// endif::waas_oob[]
 
 * *Certificate* - Copy and paste your server's certificate and private key into the certificate input box (e.g., `cat server-cert.pem server-key > certs.pem`).
 +

--- a/docs/en/enterprise-edition/content-collections/runtime-security/waas/deploy-waas/fragments/create-waas-rule.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/waas/deploy-waas/fragments/create-waas-rule.adoc
@@ -20,24 +20,24 @@ NOTE: The maximum duration in seconds for reading the entire request, including 
 endif::waas_inline_hosts[]
 
 . Choose the rule *Scope* by specifying the resource collection(s) to which it applies.
-+
-image::runtime-security/waas-select-scope.png[]
+// +
+// image::runtime-security/waas-select-scope.png[]
 +
 ifdef::waas_containers[]
 Collections define a combination of image names and one or more elements to which WAAS should attach itself to protect the web application:
-+
-image::runtime-security/waas-define-collection.png[]
+// +
+// image::runtime-security/waas-define-collection.png[]
 +
 NOTE: Applying a rule to all images using a wild card (`*`) is invalid - instead, only specify your web application images.
 endif::waas_containers[]
 
 ifdef::waas_hosts[]
 Collections define a combination of hosts to which WAAS should attach itself to protect the web application:
-+
-image::runtime-security/waas-define-host-collection.png[]
-ifdef::waas_oob_hosts[]
-image::runtime-security/waas-define-collection-oob-hosts.png[]
-endif::waas_oob_hosts[]
+// +
+// image::runtime-security/waas-define-host-collection.png[]
+// ifdef::waas_oob_hosts[]
+// image::runtime-security/waas-define-collection-oob-hosts.png[]
+// endif::waas_oob_hosts[]
 +
 NOTE: Applying a rule to all hosts/images using a wild card (`*`) is invalid and a waste of resources.
 WAAS only needs to be applied to hosts that run applications that transmit and receive HTTP/HTTPS traffic.

--- a/docs/en/enterprise-edition/content-collections/runtime-security/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/waas/deploy-waas/fragments/defender-deployment-failed-troubleshoot.adoc
@@ -1,6 +1,6 @@
 AWS CloudFormation stack failed to deploy the WAAS agentless resources because Prisma Console is not accessible from AWS.
 
-image::runtime-security/err4-failedcondition-received.png[]
+// image::runtime-security/err4-failedcondition-received.png[]
 
 . Make sure that the IP address of Prisma Console in the VPC configuration is public.
 . Check if the Defender instance has a public IP address.


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

This PR comments out the images in all fragments.
This is a workaround until the infrastructure issues preventing the images from rendering is solved. This PR can then be reverted.

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=frag-images
