### PR TITLE
Fix typos in open-policy-agent.adoc

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/access-control/open-policy-agent.adoc
+++ b/docs/en/compute-edition/32/admin-guide/access-control/open-policy-agent.adoc
@@ -39,9 +39,9 @@ After registering to intercept admission requests, they assess requests against 
 In Kubernetes terms, these are known as _validating admission webhooks_.
 
 The Prisma Cloud validating admission webhook handles the API server's AdmissionReview requests, and returns decisions in an AdmissionReview object.
-When configuring Prisma Cloud, you'll create a ValidatingWebookConfiguration object, which sets up the Defender service to intercept all create, update, and connect calls to the API server.
+When configuring Prisma Cloud, you'll create a ValidatingWebhookConfiguration object, which sets up the Defender service to intercept all create, update, and connect calls to the API server.
 
-The default ValidatingWebookConfiguration provided here sets failurePolicy to Ignore.
+The default ValidatingWebhookConfiguration provided here sets failurePolicy to Ignore.
 The failure policy specifies how your cluster handles unrecognized errors and timeout errors from the admission webhook.
 When set to Ignore, the API request is allowed to continue.
 


### PR DESCRIPTION
ValidatingWebookConfiguration changed to ValidatingWebhookConfiguration

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
