### PR TITLE
Code Repo Scanning deprecated. Added description and new feature that…

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/continuous-integration/code-repo-scanning.adoc
+++ b/docs/en/compute-edition/32/admin-guide/continuous-integration/code-repo-scanning.adoc
@@ -1,46 +1,13 @@
 == Code repo scanning
 
-Both twistcli and the Jenkins plugin can evaluate package dependencies in your code repositories for vulnerabilities.
+This feature has been deprecated in version 32.02 (O'Neal Update 2). This feature has been migrated to the Application Security module
 
-The runtimes supported are:
+Replace all existing pipelines that use the twistcli utility for IaC scans with the Checkov utility
 
-* Go
-* Java
-* Node.js
-* Python
-* Ruby
+Refer to the links below for the Application Security Module in Prisma Cloud Enterprise
 
-[.task]
-=== Integrate code scanning into CI builds
+Getting Started - https://docs.prismacloud.io/en/enterprise-edition/content-collections/application-security/get-started/get-started
+Enable Application Security - https://docs.prismacloud.io/en/enterprise-edition/content-collections/application-security/get-started/enable-application-security
+Onboard Code Repositories - https://docs.prismacloud.io/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/connect-code-and-build-providers
+Integrate IDE - https://docs.prismacloud.io/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/ides/ides
 
-Point the Jenkins plugin to your code repo in the build directory.
-
-*Prerequisites:* You've xref:../continuous-integration/jenkins-plugin.adoc[installed and configured the Prisma Cloud Jenkins plugin].
-
-[.procedure]
-. In your Jenkins job configuration, click *Add build step*, and select *Scan Prisma Cloud Code Repositories*.
-
-. Configure the repo scan.
-+
-image::code_repo_scanning_config_scan.png[width=550]
-
-.. In *Repository Name*, specify the name to be used when reporting the results in Console.
-
-.. In *Repository path*, specify the path to the repo in the build directory.
-+
-For example, it could simply be the current working directory (`.`) or some relative directory.
-
-. Click *Save*, and then execute a build job.
-+
-To see the scan results, log into Console, and go to *Monitor > Vulnerabilities > Code repositories > CI*.
-Prisma Cloud evaluates the contents of the repo according to the policy you've specified in *Defend Vulnerabilities > Code repositories > CI*.
-Prisma Cloud ships with a single default rule that alerts on all vulnerabilities.
-+
-image::code_repo_scanning_results.png[width=800]
-
-
-=== Use twistcli to scan repos in the CI
-
-If you're using a CI tool other than Jenkins, Prisma Cloud ships a command line utility that can be invoked from the shell in the build pipeline.
-
-For more information, see xref:../tools/twistcli-scan-code-repos.adoc[code repo scanning with twistcli].


### PR DESCRIPTION
… replaces it

This page is no longer applicable. Added information and guidance on migrating workflows to Application Security module

Fix #391 

Test URLs:
- Before: https://docs.prismacloud.io/en/classic/compute-admin-guide/vulnerability-management/code-repo-scanning
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page](https://github.com/hlxsites/prisma-cloud-docs/compare/main...jjeanclaude:prisma-cloud-docs-1:patch-3)/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
