### PR TITLE
Update Reference for Agentless Scanning for GCP accounts: Hub Scanning Mode

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes.adoc
+++ b/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes.adoc
@@ -43,6 +43,16 @@ For example, you don't need to replicate networking configuration across target 
 
 Scanners in the hub account scan target accounts independently. An agentless scanner in the hub account only scans snapshots from one target account and this ensures segregation between target accounts.
 
+[NOTE]
+====
+Even if the template successfully applies the permissions needed for the target account, they can still be overridden by Organizational policies. The permissions check that is part of the scanning mechanism will only check that the Organization project, and that the target project has the needed permissions to perform scans. If you experience permissions issues with scans, please check the IAM policy calculator in GCP, and the VPC Service Control Troubleshooter.
+====
+
+[NOTE]
+====
+The target account should have its own service account associated with it. Using the same service account key with two accounts will not work properly.
+====
+
 The following diagram gives a high level view of agentless scanning in hub account mode.
 
 image::agentless-scanning-hub-account-mode.png[width=800]


### PR DESCRIPTION
![doc-update](https://github.com/hlxsites/prisma-cloud-docs/assets/105501696/147a35d2-661f-469e-a37a-ef27c2d1bf92)

Adding notes for configuring Hub scanning mode for GCP organizations. Based on takeaways from working sessions with engineering.
