### PR TITLE
[AppSec] Non-default branch scanning is only available under the new pricing model

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-azurerepos.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-azurerepos.adoc
@@ -20,7 +20,6 @@ NOTE: Refer to <<#subscribed-events,Subscribed Events>> below for a list of even
 .. Grant the Prisma Cloud user the necessary permissions for integrating Prisma Cloud with your Azure Repos VCS, as specified in <<#user-permissions, User Permissions>> below.
 
 .. Add the Prisma Cloud IP addresses and hostname for Application Security to an xref:../../../../get-started/console-prerequisites.adoc[allow list] to enable access to the Prisma Cloud Console. 
-.. Grant *Administrator* permissions in the relevant Azure organization to the Prisma user integrating Prisma Cloud with Azure.
 
 .. On the Azure DevOps console.
 +

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/non-default-branch-scan.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/non-default-branch-scan.adoc
@@ -4,9 +4,9 @@
 
 [.task]
 
-== Non-Default Branch Scan
+You can scan branches other than the main or master, such as a feature branch or sprint  branch, to obtain a comprehensive overview of the security issues in those branches before merging them into the main branch. 
 
-You can scan branches other than the main or master, such as a feature branch or sprint  branch,  to obtain a comprehensive overview of the security issues in those branches before merging them into the main branch.  
+NOTE: Non-default branch scanning functionality is available exclusively under the new pricing model. 
 
 === Support for Non-Default Branch Scans
 


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/RLP-131847


Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
