### PR TITLE
Update agentless-scanning-modes.adoc

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes.adoc
+++ b/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes.adoc
@@ -11,7 +11,7 @@ There are two ways you can set up agentless scanning with Prisma Cloud.
 
 [NOTE]
 ====
-Hub account mode is only supported for AWS and GCP.
+Hub account mode is supported for AWS and GCP. Azure Hub Account Scanning is now available as of January 7th, 2024
 ====
 
 [#same-account-mode]
@@ -42,6 +42,16 @@ For example, you don't need to replicate networking configuration across target 
 * In GCP, snapshots are created directly within the hub account.
 
 Scanners in the hub account scan target accounts independently. An agentless scanner in the hub account only scans snapshots from one target account and this ensures segregation between target accounts.
+
+[NOTE]
+====
+For GCP accounts with organizations only: Even if the IAM permissions template successfully applies the permissions needed for the target account, they can still be overridden by Organizational policies. The permissions check that is part of the scanning mechanism will only check that the Organization project, and that the target project has the needed permissions to perform scans. If you experience permissions issues with scans, please check the IAM policy calculator in GCP, and the VPC Service Control Troubleshooter.
+====
+
+[NOTE]
+====
+For GCP accounts with organizations only: The target account should have its own service account associated with it. Using the same service account key with two accounts will not work properly.
+====
 
 The following diagram gives a high level view of agentless scanning in hub account mode.
 


### PR DESCRIPTION
Issues 389 and 390
Added notes for configuration in GCP. Updated note to add support for Azure Hub Scanning

URL for reference

Original: https://docs.prismacloud.io/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes#hub-account-mode
Proposed Edit: https://github.com/hlxsites/prisma-cloud-docs/compare/main...jjeanclaude:prisma-cloud-docs-1:patch-5
docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes.adoc

Fix #389
Fix #390

Test URLs:
- Before: https://main--/blob/main/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes.adoc--hlxsites.hlx.page/
- After: https://jjeanclaude/prisma-cloud-docs-1--prisma-cloud-docs--hlxsites.hlx.page/](https://jjeanclaude--/blob/main/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning-modes.adoc--hlxsites.hlx.page/)
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=jjeanclaude/prisma-cloud-docs-1
