### PR TITLE
fix: custom section ids

### DIFF
--- a/worker/src/util/adoc2html.ts
+++ b/worker/src/util/adoc2html.ts
@@ -177,19 +177,21 @@ class FranklinConverter implements AdocTypes.Converter {
         const closer = this.sectionDepth > 0 ? '</div>' : '';
         this.sectionDepth += 1;
 
+        // only apply section meta anchors on sections, and when an id is explicitly authored
+        const sectionMeta = !id.startsWith('_') && this.sectionDepth > 1
+          ? `\n${this.makeBlock('section-metadata', `<div><div>id</div><div>${id}</div></div>`)}`
+          : '';
+
         const content = `
+          ${sectionMeta}
           ${title ? `<${tag}${!id.startsWith('_') ? ` id="${id}"` : ''}>${title}</${tag}>` : ''}
           ${blocks.map((block) => this.convert(block)).join('\n')}`;
 
         const wrapper = `${closer}<div>${content}${closer ? '' : '</div>'}`;
 
-        // only apply section meta anchors on sections, and when an id is explicitly authored
-        const sectionMeta = !id.startsWith('_') && this.sectionDepth > 1
-          ? `\n${this.makeBlock('section-metadata', `<div><div>id</div><div>${id}</div></div>`)}`
-          : '';
         this.sectionDepth -= 1;
 
-        return wrapper + sectionMeta;
+        return wrapper;
       },
       literal: (node) => {
         const content = node.getContent();


### PR DESCRIPTION
Fix issue with custom section ids being rendered as para text instead of being properly applied as the secion/div id.

Fix [hlxsites/prisma-cloud-docs-website#205](https://github.com/hlxsites/prisma-cloud-docs-website/issues/205)
