### PR TITLE
[AppSec] Added permissions required to integrate Prisma Cloud plugin with IDEs

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
@@ -31,13 +31,15 @@ NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code S
 
 . *Permissions*.
 
-To integrate the plugin, *Developer* or *System Administrator* roles are required.
+.. To integrate the plugin, *Developer* or *System Administrator* roles are required.
 
 .. For *GRBAC*, provide the following permissions.
 +
 * *Policies*: 'View' permissions
 * *Projects*: 'View' permissions
 * *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
+
+
 
 . On Prisma Cloud.
 +

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
@@ -39,7 +39,7 @@ NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code S
 * *Projects*: 'View' permissions
 * *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
 +
-For information about roles and permissions on Prisma Cloud, referbto xref:../../administration/prisma-cloud-admin-permissions.adoc[Prisma Cloud Administrator Permissions].
+For information about roles and permissions on Prisma Cloud, refer to xref:../../administration/prisma-cloud-admin-permissions.adoc[Prisma Cloud Administrator Permissions].
 
 
 . On Prisma Cloud.

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
@@ -29,7 +29,7 @@ NOTE: The Prisma Cloud Code Security plugin supports all JetBrains products.
 +
 NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code Security.
 
-. *Permissions*.
+. Permissions.
 
 .. To integrate the plugin, *Developer* or *System Administrator* roles are required.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
@@ -38,7 +38,8 @@ NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code S
 * *Policies*: 'View' permissions
 * *Projects*: 'View' permissions
 * *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
-
++
+For information about roles and permissions on Prisma Cloud, referbto xref:../../administration/prisma-cloud-admin-permissions.adoc[Prisma Cloud Administrator Permissions].
 
 
 . On Prisma Cloud.

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-jetbrains.adoc
@@ -29,6 +29,16 @@ NOTE: The Prisma Cloud Code Security plugin supports all JetBrains products.
 +
 NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code Security.
 
+. *Permissions*.
+
+To integrate the plugin, *Developer* or *System Administrator* roles are required.
+
+.. For *GRBAC*, provide the following permissions.
++
+* *Policies*: 'View' permissions
+* *Projects*: 'View' permissions
+* *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
+
 . On Prisma Cloud.
 +
 * Add the Prisma Cloud IP addresses and hostname for Application Security to an xref:../../../../get-started/console-prerequisites.adoc[allow list] to enable access to the Prisma Cloud console

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
@@ -35,7 +35,8 @@ NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code S
 * *Policies*: 'View' permissions
 * *Projects*: 'View' permissions
 * *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
-
++
+For information about roles and permissions on Prisma Cloud, referbto xref:../../administration/prisma-cloud-admin-permissions.adoc[Prisma Cloud Administrator Permissions].
 
 . On Prisma Cloud.
 +

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
@@ -26,6 +26,16 @@ You can prioritize findings and address the most critical issues by filtering th
 +
 NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code Security.
 
+. *Permissions*.
+
+To integrate the plugin, *Developer* or *System Administrator* roles are required.
+
+.. For *GRBAC*, provide the following permissions.
++
+* *Policies*: 'View' permissions
+* *Projects*: 'View' permissions
+* *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
+
 . On Prisma Cloud.
 +
 * Add the Prisma Cloud IP addresses and hostname for Application Security to an xref:../../../../get-started/console-prerequisites.adoc[allow list] to enable access to the Prisma Cloud console 

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
@@ -26,7 +26,7 @@ You can prioritize findings and address the most critical issues by filtering th
 +
 NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code Security.
 
-. *Permissions*.
+. Permissions.
 
 .. To integrate the plugin, *Developer* or *System Administrator* roles are required.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
@@ -36,7 +36,7 @@ NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code S
 * *Projects*: 'View' permissions
 * *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
 +
-For information about roles and permissions on Prisma Cloud, referbto xref:../../administration/prisma-cloud-admin-permissions.adoc[Prisma Cloud Administrator Permissions].
+For information about roles and permissions on Prisma Cloud, refer to xref:../../administration/prisma-cloud-admin-permissions.adoc[Prisma Cloud Administrator Permissions].
 
 . On Prisma Cloud.
 +

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/connect-vscode.adoc
@@ -28,13 +28,14 @@ NOTE: The plugin automatically invokes the latest version of Prisma Cloud Code S
 
 . *Permissions*.
 
-To integrate the plugin, *Developer* or *System Administrator* roles are required.
+.. To integrate the plugin, *Developer* or *System Administrator* roles are required.
 
 .. For *GRBAC*, provide the following permissions.
 +
 * *Policies*: 'View' permissions
 * *Projects*: 'View' permissions
 * *Repositories*: ('View' and 'Create') OR ('View' and 'Update') permissions
+
 
 . On Prisma Cloud.
 +


### PR DESCRIPTION
Jira ticket 👍 https://redlock.atlassian.net/browse/RLP-133492
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
