### PR TITLE
[AppSec] Added port 443 limitation to GitHub and GitLab enterprise integrations

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
@@ -16,6 +16,7 @@ NOTE: Refer to <<#subscribed-events,Subscribed Events>> below for a list of even
 .. Grant the Prisma Cloud user the necessary permissions for integrating Prisma Cloud with your GitHub Server VCS, as specified in <<#user-permissions, User Permissions>> below.
 .. Add the Prisma Cloud IP addresses and hostname for Application Security to an xref:../../../../get-started/console-prerequisites.adoc[allow list] to enable access to the Prisma Cloud Console. 
 .. Ensure that the provided hostname or IP address is resolvable on public DNS servers.
+.. Ensure the use of the default port 443 for the integration.
 
 . On the Prisma Cloud Application Security console.
 .. In Application Security, select *Settings* > *Connect Provider* > *Code & Build Providers*.

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab-selfmanaged.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab-selfmanaged.adoc
@@ -17,6 +17,7 @@ NOTE: Refer to <<#subscribed-events,Subscribed Events>> below for a list of subs
 .. Grant the Prisma Cloud user the necessary permissions for integrating Prisma Cloud with your GitLab Self-managed VCS, as specified in <<#user-permissions, User Permissions>> below.
 
 .. Add the Prisma Cloud IP addresses and hostname for Application Security to an xref:../../../../get-started/console-prerequisites.adoc[allow list] to enable access to the Prisma Cloud Console. 
+.. Ensure the use of the default port 443 for the integration.
 
 . On the Prisma Cloud Application Security console.
 


### PR DESCRIPTION

Jira ticket :https://redlock.atlassian.net/browse/RLP-133730

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
