### PR TITLE
[AppSec] Rephrased "repo" permissions required for GitHub Server integration

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket.adoc
@@ -100,7 +100,7 @@ Authorize the user integrating Prisma Cloud with your Bitbucket instance with th
 
 * *project*: Provides access to view the project or projects. This scope implies the `repository` scope, giving read access to all the repositories in a project or projects. 
 
-* *repository*: Provides read access to a repository or repositories. Note that this scope does not give access to a repository's pull requests. Includes 'access to the repo's source code', 'clone over HTTPS', 'access the file browsing API', 'download zip archives of the repo's contents', 'the ability to view and use the issue tracker on any repo (created issues, comment, vote, etc)', 'the ability to view and use the wiki on any repo (create/edit pages)''
+* *repository*: Provides read access to a repository or repositories. Note that this scope does not give access to a repository's pull requests. Includes 'access to the repo's source code', 'clone over HTTPS', 'access the file browsing API', 'download zip archives of the repo's contents', 'the ability to view and use the issue tracker on any repo (created issues, comment, vote, etc)', 'the ability to view and use the wiki on any repo (create/edit pages)'
 
 * *repository:write*: Provides write (not admin) access to a repository or repositories. No distinction is made between public and private repositories. This scope implicitly grants the `repository` scope, which does not need to be requested separately. This scope alone does not give access to the pull requests API. Includes 'push access over HTTPS' and 'fork repos'
 

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
@@ -86,7 +86,7 @@ NOTE: It may take up to 3 minutes for the integration status to be updated.
 
 Authorize the user integrating Prisma Cloud with your GitHub Server instance with the following permissions.
 
-* *repo*: Grants full access to public and private repositories, including read and write access to code, commit statuses, repository invitations, collaborators, deployment statuses, and repository webhooks
+* *repo*: Grants full access to public and private repositories, including read and write access to code, commit statuses, repository invitations, collaborators, deployment statuses, and the capability to subscribe the repository to receive new webhook notifications or events
 +
 NOTE: In addition to repository-related resources, the repository scope also grants access to manage organization-owned resources, including projects, invitations, team memberships, and webhooks. This scope also grants the ability to manage projects owned by users
 


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/RLP-134714

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
