### PR TITLE
[Runtime Security]Remove cost implication note in agentless scanning

### DIFF
--- a/docs/en/classic/compute-admin-guide/agentless-scanning/agentless-scanning.adoc
+++ b/docs/en/classic/compute-admin-guide/agentless-scanning/agentless-scanning.adoc
@@ -187,13 +187,6 @@ If an instance type is not available the agentless scan process falls back to th
 
 * Standard_DS4_v2
 
-[NOTE]
-====
-Enabling Agentless Scan on Azure with an https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources[active scope lock] has a significant cost implication. The temporary resources that Prisma Cloud deploys for scanning cannot be deleted and continue to incur costs (VMs, disks, snapshots) because these resources are locked. The Prisma Cloud console generates a log entry that reports a _409 Conflict_ and _ERROR CODE: ScopeLocked_.
-
-To ensure that you do not incur addtional costs, you must evaluate if the scope lock is necessary for your operations. Consider releasing the scope lock or have a different method to delete the temporary resources to prevent any cost overhead.
-====
-
 ==== GCP
 
 * e2-standard-8

--- a/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning.adoc
+++ b/docs/en/compute-edition/32/admin-guide/agentless-scanning/agentless-scanning.adoc
@@ -187,13 +187,6 @@ If an instance type is not available the agentless scan process falls back to th
 
 * Standard_DS4_v2
 
-[NOTE]
-====
-Enabling Agentless Scan on Azure with an https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources[active scope lock] has a significant cost implication. The temporary resources that Prisma Cloud deploys for scanning cannot be deleted and continue to incur costs (VMs, disks, snapshots) because these resources are locked. The Prisma Cloud console generates a log entry that reports a _409 Conflict_ and _ERROR CODE: ScopeLocked_.
-
-To ensure that you do not incur addtional costs, you must evaluate if the scope lock is necessary for your operations. Consider releasing the scope lock or have a different method to delete the temporary resources to prevent any cost overhead.
-====
-
 ==== GCP
 
 * e2-standard-8

--- a/docs/en/enterprise-edition/content-collections/runtime-security/agentless-scanning/agentless-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/agentless-scanning/agentless-scanning.adoc
@@ -184,12 +184,6 @@ If an instance type is not available the agentless scan process falls back to th
 
 * Standard_DS4_v2
 
-[NOTE]
-====
-Enabling Agentless Scan on Azure with an https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/lock-resources[active scope lock] has a significant cost implication. The temporary resources that Prisma Cloud deploys for scanning cannot be deleted and continue to incur costs (VMs, disks, snapshots) because these resources are locked. The Prisma Cloud console generates a log entry that reports a _409 Conflict_ and _ERROR CODE: ScopeLocked_.
-To ensure that you do not incur addtional costs, you must evaluate if the scope lock is necessary for your operations. Consider releasing the scope lock or have a different method to delete the temporary resources to prevent any cost overhead.
-====
-
 ==== GCP
 
 * e2-standard-8


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=cwp-50822
