### PR TITLE
Update agentless-scanning.adoc

### DIFF
--- a/docs/en/classic/compute-admin-guide/agentless-scanning/agentless-scanning.adoc
+++ b/docs/en/classic/compute-admin-guide/agentless-scanning/agentless-scanning.adoc
@@ -69,7 +69,7 @@ Ensure that you follow these guidelines.
 
 * Configure the relevant network resources under *Compute > Cloud Accounts > Edit Cloud Account > Agentless scanning > Advanced settings*.
 
-** In AWS: Specify the deployed Security group.
+** In AWS: Specify the deployed Security group name and Subnet name.
 
 ** In Azure: Specify the deployed Security group ID and Subnet ID.
 


### PR DESCRIPTION
AWS Agentless scanning allows users to specify a subnet name and/or Security group name