### PR TITLE
[AppSec] Transport  - fixed step 4.1 of "Select Transporter and ensure Domain Name Consistency"

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/manage-network-tunnel/select-transporter-domain-consistency.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/manage-network-tunnel/select-transporter-domain-consistency.adoc
@@ -18,7 +18,7 @@ image::application-security/select-transporter1.1.png[]
 + 
 . In *Application Security*, select *Home* > *Settings* > *Connect Provider* > *Code & Build Providers* > select your integrated [PROVIDER] from the catalog.
 . In the relevant fields of the *Configure Domain* step of the integration wizard.
-.. Provide the *Domain name* of the Transporter that you selected.
+.. Provide the *Domain name* of your self-hosted version control system.
 .. Check the *Use a Transporter for secured connection box* > select the Transporter that you configured from the dropdown menu in the *Transporter* field.
 
 NOTE: This field is only available after a socket is opened and a connection is established with the Transporter.


### PR DESCRIPTION
Jira: https://redlock.atlassian.net/browse/RLP-135174

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
