### PR TITLE
[Worker] Add support for the imagesdir attr

### DIFF
--- a/worker/src/util/adoc2html.ts
+++ b/worker/src/util/adoc2html.ts
@@ -300,7 +300,7 @@ class FranklinConverter implements AdocTypes.Converter {
       },
       inline_image: (node) => this.templates.image(node as AdocTypes.AbstractBlock),
       image: (node) => {
-        const src = node.getAttribute('target') as string | undefined;
+        const src = node.getImageUri(node.getAttribute('target', '') as string);
         if (!src) {
           return '';
         }


### PR DESCRIPTION
Currently, the worker's converter for images doesn't support the `imagesdir` attribute. We'd like to be able to set a value in `book.yml` and then have it propagate across all image macros in the book.

AsciiDoctor user manual for `imagesdir`: https://docs.asciidoctor.org/asciidoc/latest/macros/images-directory/

Effectively, `getImageUri()` combines the value in `imagesdir`  (if there is one) along with the image macro target ( `image::<TARGET>`) to get a value that can be used directly in `href` in the HTML5 `image` tag.