### PR TITLE
[AppSec] Added repo permissions to vcs integrations excepting GitHub Cloud

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-azurerepos.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-azurerepos.adoc
@@ -131,6 +131,8 @@ NOTE: You cannot delete the integration from *Repositories* for an account integ
 
 Authorize the user integrating Prisma Cloud with your Azure Repos instance with the following permissions.
 
+* *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
+
 * *Identity (read) [vso.identity]*: This permission grants read access to identity-related information or configurations within Azure DevOps. It allows the user to view details about users, groups, or other identity-related entities
 
 * *Build (read) [vso.build]*: This permission grants read access to information related to builds in Azure DevOps. It allows the user to view details about build pipelines, build definitions, and build execution status

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket.adoc
@@ -100,6 +100,8 @@ Authorize the user integrating Prisma Cloud with your Bitbucket instance with th
 
 * *project*: Provides access to view the project or projects. This scope implies the `repository` scope, giving read access to all the repositories in a project or projects. 
 
+* *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
+
 * *repository*: Provides read access to a repository or repositories. Note that this scope does not give access to a repository's pull requests. Includes 'access to the repo's source code', 'clone over HTTPS', 'access the file browsing API', 'download zip archives of the repo's contents', 'the ability to view and use the issue tracker on any repo (created issues, comment, vote, etc)', 'the ability to view and use the wiki on any repo (create/edit pages)'
 
 * *repository:write*: Provides write (not admin) access to a repository or repositories. No distinction is made between public and private repositories. This scope implicitly grants the `repository` scope, which does not need to be requested separately. This scope alone does not give access to the pull requests API. Includes 'push access over HTTPS' and 'fork repos'

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
@@ -86,6 +86,8 @@ NOTE: It may take up to 3 minutes for the integration status to be updated.
 
 Authorize the user integrating Prisma Cloud with your GitHub Server instance with the following permissions.
 
+* *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
+
 * *repo*: Grants full access to public and private repositories, including read and write access to code, commit statuses, repository invitations, collaborators, deployment statuses, and the capability to subscribe the repository to receive new webhook notifications or events
 +
 NOTE: In addition to repository-related resources, the repository scope also grants access to manage organization-owned resources, including projects, invitations, team memberships, and webhooks. This scope also grants the ability to manage projects owned by users

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab-selfmanaged.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab-selfmanaged.adoc
@@ -141,6 +141,8 @@ Authorize the user integrating Prisma Cloud with your GitLab Self-managed instan
 
 * *api*: Grants full *read* and *write* access to the API, including all groups and projects, as well as permissions to interact with the container registry, the dependency proxy, and the package registry
 
+* *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
+
 NOTE: A repository can only be integrated with a single integration at a time. The first integration that connects with the repository will be the one it is assigned to. This means that if multiple integrations attempt to connect to the same repository, only the first integration to establish the connection will be associated with that repository.
 
 [#subscribed-events]

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab.adoc
@@ -107,6 +107,8 @@ Authorize the user integrating Prisma Cloud with your GitLab instance with the f
 
 * *api*: Grants full *read* and *write* access to the API, including all groups and projects, as well as permissions to interact with the container registry, the dependency proxy, and the package registry
 
+* *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
+
 NOTE: A repository can only be integrated with a single integration at a time. The first integration that connects with the repository will be the one it is assigned to. This means that if multiple integrations attempt to connect to the same repository, only the first integration to establish the connection will be associated with that repository.
 
 [#subscribed-events]


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/BCE-31662

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
