### PR TITLE
[Runtime Security] Patch for blurb CWP-56798

### DIFF
--- a/docs/en/compute-edition/32/rn/release-information/release-notes-32-04.adoc
+++ b/docs/en/compute-edition/32/rn/release-information/release-notes-32-04.adoc
@@ -25,7 +25,7 @@ Review the https://docs.prismacloud.io/en/compute-edition/32/admin-guide/install
 
 // You can download the release image from the Palo Alto Networks Customer Support Portal, or use a program or script (such as curl, wget) to download the release image directly from our CDN:
 
-//[LINK]
+// [LINK]
 
 toc::[]
 
@@ -65,7 +65,7 @@ You can upgrade the Prisma Cloud Console from a major release to the next major 
 //CWP-56798
 |*Blobstore Scanning Defender Upgrade for Tanzu Customers*
 |Enhanced the existing `blobstore` scanning feature for Tanzu customers. As a part of this enhancement, existing `blobstore` scanning defenders will now appear disconnected and new defender instances will be automatically created to replace them. The disconnected `blobstore` will disappear after 24 hours as part of the retention process. This upgrade excludes Linux and Windows defenders (Full coverage defenders).
-If you have have configured `blobstore` scanning and assigned it to a specific `blobstore` defender after the release of 32.04, you are required to manually edit the configurations and change it to a newly created `blobstore` defender scanner. This release will also introduce a new tile support - Jimmy for TAS.
+If you have have configured `blobstore` scanning and assigned it to a specific `blobstore` defender after the release of 32.04, you are required to manually edit the configurations and change it to a newly created `blobstore` defender scanner. This release will also introduce a new tile support - jammy for TAS.
 
 //CWP-56557
 |*Added Account ID information to the Defenders dashboard*

--- a/docs/en/enterprise-edition/rn/prisma-cloud-release-info/classic-releases/prisma-cloud-compute-release-information/features-introduced-in-compute-march-2024.adoc
+++ b/docs/en/enterprise-edition/rn/prisma-cloud-release-info/classic-releases/prisma-cloud-compute-release-information/features-introduced-in-compute-march-2024.adoc
@@ -40,7 +40,7 @@ To prepare for this update, upgrade your Defenders from version `v30.xx` or an e
 //CWP-56798
 |*Blobstore Scanning Defender Upgrade for Tanzu Customers*
 |Enhanced the existing `blobstore` scanning feature for Tanzu customers. As a part of this enhancement, existing `blobstore` scanning defenders will now appear disconnected and new defender instances will be automatically created to replace them. The disconnected `blobstore` will disappear after 24 hours as part of the retention process. This upgrade excludes Linux and Windows defenders (Full coverage defenders).
-If you have have configured `blobstore` scanning and assigned it to a specific `blobstore` defender after the release of 32.04, you are required to manually edit the configurations and change it to a newly created `blobstore` defender scanner. This release will also introduce a new tile support - Jimmy for TAS.
+If you have have configured `blobstore` scanning and assigned it to a specific `blobstore` defender after the release of 32.04, you are required to manually edit the configurations and change it to a newly created `blobstore` defender scanner. This release will also introduce a new tile support - jammy for TAS.
 
 //CWP-56557
 |*Added Account ID information to the Defenders dashboard*


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix: This is patch update for blurb CWP-56798 addressed in #505 and #506 

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
