### PR TITLE
[AppSec] Add log capability for Helm charts in Transporter docs

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-docker.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-docker.adoc
@@ -124,7 +124,7 @@ For more on health checks see xref:transporter-health-check.adoc[Transporter Hea
 
 Configure logging to capture and store system events, errors, and activities for analysis and troubleshooting purposes by adding an environment variable. By default, set the logging level to `info`. You can adjust the `logLevel` parameter. Examples: `-e LOG_LEVEL=debug`, `- LOG_LEVEL=debug`. 
 
-See step 4.1 *Option #1: Run Image through Docker Commands* or step 4.2 *Option #2: Run Image through Docker Compose* of the deployment setup above for logging configuration options. 
+See *steps 4.1, 4.2* of the deployment setup above to enable logging configuration options. 
 
 [#self-signed-certificates]
 === Self Signed Certificates

--- a/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-docker.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-docker.adoc
@@ -64,7 +64,7 @@ Use *Docker commands* to create a Docker image that contains the code and config
 
 * Copy and paste the command from the *Docker Run CLI command* in your terminal to run the pulled Docker image.
 
-* *Enable debug level logs*: Add  the `-e LOG_LEVEL=debug \` environment variable to the list of variables in the *Docker Run CLI Command* field. 
+* *Enable debug level logs*: Add  the `-e LOG_LEVEL=info \` environment variable to the list of variables in the *Docker Run CLI Command* field. 
 +
 image::application-security/transporter-log-debug1.1.png[]
 
@@ -76,7 +76,7 @@ Use *Docker compose* to define a Docker application that contains the code and c
 
 * Copy and paste the command from the *Docker-Compose CLI Command* field in your CLI terminal to run the 'docker-compose' command.
 
-* *Enable debug level logs*: Add  the `- LOG_LEVEL=debug` environment variable to the list of  variables in the *Docker Compose Content* field .
+* *Enable debug level logs*: Add  the `- LOG_LEVEL=info` environment variable to the list of  variables in the *Docker Compose Content* field .
 +
 NOTE: The `-d` value in the command specifies the name of the Docker Compose yml file.
 
@@ -122,7 +122,9 @@ For more on health checks see xref:transporter-health-check.adoc[Transporter Hea
 
 === Enable Logs
 
-Configure logging to capture and store system events, errors, and activities for analysis and troubleshooting purposes by adding an environment variable. See step 4.1 *Option #1: Run Image through Docker Commands* or step 4.2 *Option #2: Run Image through Docker Compose* of the deployment setup above for logging configuration options. 
+Configure logging to capture and store system events, errors, and activities for analysis and troubleshooting purposes by adding an environment variable. By default, set the logging level to `info`. You can adjust the `logLevel` parameter. Examples: `-e LOG_LEVEL=debug`, `- LOG_LEVEL=debug`. 
+
+See step 4.1 *Option #1: Run Image through Docker Commands* or step 4.2 *Option #2: Run Image through Docker Compose* of the deployment setup above for logging configuration options. 
 
 [#self-signed-certificates]
 === Self Signed Certificates

--- a/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-helmcharts.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-helmcharts.adoc
@@ -271,5 +271,5 @@ For more on health checks see xref:transporter-health-check.adoc[Transporter Hea
 
 Configure logging to capture and store system events, errors, and activities for analysis and troubleshooting purposes through both CLI commands and the `values.yaml` file. By default, the logging level is set to `info`. You can customize the logging level by adjusting the `logLevel` parameter. Example: `--set transporter.logLevel=debug`.
 
-* *CLI commands*: To enable logging through CLI commands, add this parameter: `--set transporter.logLevel=debug` to *step 2* option #1 Deploy with TLS on the pod or option #2 Deploy with Ingress Enabled and TLS Configured on Ingress (Pod TLS Disabled) of <<#install-helm-cli,Install Transporter using the Helm install command in the CLI>>     
+* *CLI commands*: To enable logging through CLI commands, add this parameter: `--set transporter.logLevel=debug` to *step 2* option #1 Deploy with TLS on the pod or option #2 Deploy with Ingress Enabled and TLS Configured on Ingress (Pod TLS Disabled) of <<#install-helm-cli,Install Transporter using the Helm install command in the CLI>> above    
 * *values.yaml* file: Logging values are pre-configured in the `values.yaml` chart file 

--- a/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-helmcharts.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-helmcharts.adoc
@@ -117,6 +117,7 @@ helm install transporter \
     --set transporter.transporterAlias=<transporter_alias_provided_by_prisma_cloud> \
     --set transporter.transporterUrl=transporter.bridgecrew.cloud \
     --set transporter.tls.enabled=true \
+    --set transporter.logLevel=info \ 
     --set "ingress.hosts[0].host=transporter.bridgecrew.cloud" \
     --set "ingress.hosts[0].paths[0].path='\'" \
     --set tls.enabled=true \
@@ -142,7 +143,8 @@ helm install transporter \
     --set transporter.secretKey=<PRISMA_ACCESS_KEY> \
     --set transporter.serverUrl=wss://api0-transporter/wss/transporter \
     --set transporter.transporterAlias=transporter-alias \
-    --set "transporter.transporterUrl=transporter.bridgecrew.cloud" \
+    --set "transporter.transporterUrl=transporter.bridgecrew.cloud" \    
+    --set transporter.logLevel=info \ 
     --set ingress.enabled=true \
     --set "ingress.hosts[0].host=transporter.bridgecrew.cloud" \
     --set "ingress.hosts[0].paths[0].path='\'" \
@@ -186,7 +188,7 @@ image::application-security/transporter-logs1.png[]
 [.task]
 
 [#install-yml]
-=== Install Transporter through the `values.yaml` File
+=== Install Transporter through the `values.yaml` file
 
 [.procedure]
 . Execute *steps 1-8* of <<install-helm-cli,Install Transporter through Helm install command on CLI>> above.
@@ -264,3 +266,10 @@ image::application-security/transporter-verify-connectivity-ui1.1.png[]
 The health check provides about the VCS integrations and the most recent connection establishment time. The Transporter runs health checks every hour, and you manually refresh the connection at any time through Prisma Cloud.
 
 For more on health checks see xref:transporter-health-check.adoc[Transporter Health Check]. 
+
+=== Enable Logs
+
+Configure logging to capture and store system events, errors, and activities for analysis and troubleshooting purposes through both CLI commands and the `values.yaml` file. By default, the logging level is set to `info`. You can customize the logging level by adjusting the `logLevel` parameter. Example: `--set transporter.logLevel=debug`.
+
+* *CLI commands*: To enable logging through CLI commands, add this parameter: `--set transporter.logLevel=debug` to *step 2* option #1 Deploy with TLS on the pod or option #2 Deploy with Ingress Enabled and TLS Configured on Ingress (Pod TLS Disabled) of <<#install-helm-cli,Install Transporter using the Helm install command in the CLI>>     
+* *values.yaml* file: Logging values are pre-configured in the `values.yaml` chart file 

--- a/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-helmcharts.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/manage-network-tunnel/deploy-transporter-helmcharts.adoc
@@ -271,5 +271,5 @@ For more on health checks see xref:transporter-health-check.adoc[Transporter Hea
 
 Configure logging to capture and store system events, errors, and activities for analysis and troubleshooting purposes through both CLI commands and the `values.yaml` file. By default, the logging level is set to `info`. You can customize the logging level by adjusting the `logLevel` parameter. Example: `--set transporter.logLevel=debug`.
 
-* *CLI commands*: To enable logging through CLI commands, add this parameter: `--set transporter.logLevel=debug` to *step 2* option #1 Deploy with TLS on the pod or option #2 Deploy with Ingress Enabled and TLS Configured on Ingress (Pod TLS Disabled) of <<#install-helm-cli,Install Transporter using the Helm install command in the CLI>> above    
+* *CLI commands*: To enable logging through CLI commands, add this parameter: `--set transporter.logLevel=debug` in either *step 2* option #1 Deploy with TLS on the pod or option #2 Deploy with Ingress Enabled and TLS Configured on Ingress (Pod TLS Disabled) from the <<#install-helm-cli,Install Transporter using the Helm install command in the CLI>> section above   
 * *values.yaml* file: Logging values are pre-configured in the `values.yaml` chart file 


### PR DESCRIPTION

Jira ticket https://redlock.atlassian.net/browse/RLP-136561

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
