### PR TITLE
[CAS ]Added supported file types and entropy analysis to Secrets docs

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -1,12 +1,12 @@
 == Secrets Scanning
 
-Application Security scan capability detects secrets^*^ in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
+Application Security scan capability detects secrets^*^in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
+
+* A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 
 *Supported file types*: Prisma Cloud scans any plaintext files that are not encrypted, not compressed (for example, `not .zip`) and not-compiled (for example, `not .jar`), for secrets. Additionally, entropy findings look for keywords to lower the noise, and those keywords must be inline with the high entropy string to be flagged.
 
 *Entropy Analysis*: Prisma Cloud analyzes the randomness of the strings within the file. Highly random strings, often referred to as "high entropy," can be indicative of a potential secret. To reduce false positives, Prisma Cloud also considers specific keywords that might be associated with secrets alongside the randomness of the data for better accuracy.
-
-* A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 
 *Limitation*: Secrets scanning in integrated version control systems supports repositories up to 4GB in size.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -1,12 +1,16 @@
 == Secrets Scanning
 
-Application Security scan capability detects secrets^*^ in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the Projects page.
+Application Security scan capability detects secrets^*^ in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
+
+*Supported file types*: Prisma Cloud scans any plaintext files that are not encrypted, not compressed (for example, `not .zip`) and not-compiled (for example, `not .jar`), for secrets. Additionally, entropy findings look for keywords to lower the noise, and those keywords must be inline with the entropic string to be flagged.
+
+*Entropy Analysis*: Prisma Cloud analyzes the randomness of the data within the file. Highly random data, often referred to as "high entropy," can be indicative of a potential secret. To reduce false positives, Prisma Cloud also considers specific keywords that might be associated with secrets alongside the randomness of the data for better accuracy.
 
 * A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 
 *Limitation*: Secrets scanning in integrated version control systems supports repositories up to 4GB in size.
 
-Prisma Cloud provides default policies designed to identify secrets that leverage both domain-specific and generic syntax. These policies match specific signatures and patterns to validate the likelihood or entropy of a string being a secret. For more information on Secrets policies refer to xref:../../../../policy-reference/secrets-policies/secrets-policies.adoc[Secrets Policies]. 
+*Policies* Prisma Cloud provides default policies designed to identify secrets that leverage both domain-specific and generic syntax. These policies match specific signatures and patterns to validate the likelihood or entropy of a string being a secret. For more information on Secrets policies refer to xref:../../../../policy-reference/secrets-policies/secrets-policies.adoc[Secrets Policies]. 
 
 === Enable the Secrets Module
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -2,9 +2,9 @@
 
 Application Security scan capability detects secrets^*^ in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
 
-*Supported file types*: Prisma Cloud scans any plaintext files that are not encrypted, not compressed (for example, `not .zip`) and not-compiled (for example, `not .jar`), for secrets. Additionally, entropy findings look for keywords to lower the noise, and those keywords must be inline with the entropic string to be flagged.
+*Supported file types*: Prisma Cloud scans any plaintext files that are not encrypted, not compressed (for example, `not .zip`) and not-compiled (for example, `not .jar`), for secrets. Additionally, entropy findings look for keywords to lower the noise, and those keywords must be inline with the high entropy string to be flagged.
 
-*Entropy Analysis*: Prisma Cloud analyzes the randomness of the data within the file. Highly random data, often referred to as "high entropy," can be indicative of a potential secret. To reduce false positives, Prisma Cloud also considers specific keywords that might be associated with secrets alongside the randomness of the data for better accuracy.
+*Entropy Analysis*: Prisma Cloud analyzes the randomness of the strings within the file. Highly random strings, often referred to as "high entropy," can be indicative of a potential secret. To reduce false positives, Prisma Cloud also considers specific keywords that might be associated with secrets alongside the randomness of the data for better accuracy.
 
 * A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -4,7 +4,7 @@ Application Security scan capability detects secrets in files within your versio
 
 * A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 
-*Supported file types*: Prisma Cloud scans any plaintext files that are not encrypted, not compressed (for example, `not .zip`) and not-compiled (for example, `not .jar`), for secrets. Additionally, entropy findings look for keywords to lower the noise, and those keywords must be inline with the high entropy string to be flagged.
+*Supported file types*: Prisma Cloud scans any plaintext files that are not encrypted, not compressed (for example, not `.zip` files) and not-compiled (for example, not `.jar` files), for secrets. Additionally, entropy findings look for keywords to lower the noise, and those keywords must be inline with the high entropy string to be flagged.
 
 *Entropy Analysis*: Prisma Cloud analyzes the randomness of the strings within the file. Highly random strings, often referred to as "high entropy," can be indicative of a potential secret. To reduce false positives, Prisma Cloud also considers specific keywords that might be associated with secrets alongside the randomness of the data for better accuracy.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -1,6 +1,6 @@
 == Secrets Scanning
 
-Application Security scan capability detects secrets^*^in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
+Application Security scan capability detects secrets[^*^] in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
 
 * A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -10,7 +10,12 @@ Application Security scan capability detects secrets in files within your versio
 
 *Limitation*: Secrets scanning in integrated version control systems supports repositories up to 4GB in size.
 
-*Policies* Prisma Cloud provides default policies designed to identify secrets that leverage both domain-specific and generic syntax. These policies match specific signatures and patterns to validate the likelihood or entropy of a string being a secret. For more information on Secrets policies refer to xref:../../../../policy-reference/secrets-policies/secrets-policies.adoc[Secrets Policies]. 
+=== Secrets Policies
+
+* *Default Policies*: Prisma Cloud provides default policies designed to identify secrets that leverage both domain-specific and generic syntax. These policies match specific signatures and patterns to validate the likelihood or entropy of a string being a secret. For more information on Secrets policies refer to xref:../../../../policy-reference/secrets-policies/secrets-policies.adoc[Secrets Policies]
+
+* *Custom Policies*: You can create custom Secrets policies tailored to your specific security posture and compliance requirements. for more information, refer to xref:../../../governance/custom-build-policies/custom-build-policies.adoc[Custom Build Policies]
+
 
 === Enable the Secrets Module
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -1,6 +1,6 @@
 == Secrets Scanning
 
-Application Security scan capability detects secrets[^*^] in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
+Application Security scan capability detects secrets in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
 
 * A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -1,6 +1,6 @@
 == Secrets Scanning
 
-Application Security scan capability detects secrets in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, or CLI, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files or storing them in dedicated files or secure storage mechanisms. The results of Secrets scanning are displayed on the *Projects* page.
+Application Security scan capability detects secrets in files within your version control system (VCS) repositories and CI/CD executions. This functionality is accessible through the Prisma Cloud console, IDE, CLI, or git hook, allowing you to address and fix the issues that led to the exposure of secrets, such as removing the secrets from configuration files and storing them in secure storage mechanisms. The results of Secrets scanning are displayed on the integration outputs and *Projects* page.
 
 * A secret is a programmatic access key that provides systems with access to information, services or assets. Developers use secrets such as API keys, encryption keys, OAuth tokens, certificates, PEM files, passwords, and passphrases to enable their application to securely communicate with other cloud services.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/secrets-scanning.adoc
@@ -6,7 +6,7 @@ Application Security scan capability detects secrets in files within your versio
 
 *Supported file types*: Prisma Cloud scans any plaintext files that are not encrypted, not compressed (for example, not `.zip` files) and not-compiled (for example, not `.jar` files), for secrets. Additionally, entropy findings look for keywords to lower the noise, and those keywords must be inline with the high entropy string to be flagged.
 
-*Entropy Analysis*: Prisma Cloud analyzes the randomness of the strings within the file. Highly random strings, often referred to as "high entropy," can be indicative of a potential secret. To reduce false positives, Prisma Cloud also considers specific keywords that might be associated with secrets alongside the randomness of the data for better accuracy.
+*Entropy Analysis*: Prisma Cloud has signatures that analyze the randomness of strings within the file. Highly random strings, often referred to as "high entropy," can be indicative of a potential secret. To reduce false positives, Prisma Cloud also considers specific keywords that might be associated with secrets alongside the randomness of the data for better accuracy.
 
 *Limitation*: Secrets scanning in integrated version control systems supports repositories up to 4GB in size.
 


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/RLP-136754

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
