### PR TITLE
Update bc-azure-2-41.adoc

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/azure-policies/azure-iam-policies/bc-azure-2-41.adoc
+++ b/docs/en/enterprise-edition/policy-reference/azure-policies/azure-iam-policies/bc-azure-2-41.adoc
@@ -33,7 +33,7 @@ This policy is checking to make sure that your Azure storage account has a Share
 * *Resource:* azurerm_storage_account
 * *Arguments:* sas_policy.expiration_period
 
-To fix this issue, the shared_access_key_enabled is not mandatory, but if it is true, you must configure your Azure Storage Account with a Shared Access Signature (SAS) expiration policy. This ensures that the SAS tokens, which are used for delegating access to your storage account resources, have an expiration time so as not to indefinitely expose your resources.
+To fix this issue, the shared_access_key_enabled is not mandatory, but if it is set to true, you need to configure your Azure Storage Account with a Shared Access Signature (SAS) expiration policy. This ensures that the SAS tokens, which are used for delegating access to your storage account resources, have an expiration time so as not to indefinitely expose your resources.
 
 [source,go]
 ----

--- a/docs/en/enterprise-edition/policy-reference/azure-policies/azure-iam-policies/bc-azure-2-41.adoc
+++ b/docs/en/enterprise-edition/policy-reference/azure-policies/azure-iam-policies/bc-azure-2-41.adoc
@@ -33,7 +33,7 @@ This policy is checking to make sure that your Azure storage account has a Share
 * *Resource:* azurerm_storage_account
 * *Arguments:* sas_policy.expiration_period
 
-To fix this issue, you need to configure your Azure Storage Account with a Shared Access Signature (SAS) expiration policy. This ensures that the SAS tokens, which are used for delegating access to your storage account resources, have an expiration time so as not to indefinitely expose your resources.
+To fix this issue, the shared_access_key_enabled is not mandatory, but if it is true, you must configure your Azure Storage Account with a Shared Access Signature (SAS) expiration policy. This ensures that the SAS tokens, which are used for delegating access to your storage account resources, have an expiration time so as not to indefinitely expose your resources.
 
 [source,go]
 ----


### PR DESCRIPTION
the shared_access_key_enabled is not mandatory, but if it is true, you must configure your Azure Storage Account with a Shared Access Signature (SAS) expiration policy.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
