### PR TITLE
Adding item to AWS AMI scanning not supported list

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/vulnerability-management/vm-image-scanning.adoc
+++ b/docs/en/compute-edition/32/admin-guide/vulnerability-management/vm-image-scanning.adoc
@@ -24,6 +24,7 @@ RHCOS uses Ignition.
 * Images that use paravirtualization.
 * Images that only support old TLS protocols (less than TLS 1.1) for utilities such as curl.
 For example, Ubuntu 12.10.
+* Microsoft Windows Servers
 
 ==== Prerequisites
 


### PR DESCRIPTION
Adding windows servers for list of AMIs not supported

Before
https://github.com/hlxsites/prisma-cloud-docs/blob/main/docs/en/compute-edition/32/admin-guide/vulnerability-management/vm-image-scanning.adoc

After
https://github.com/hlxsites/prisma-cloud-docs/edit/main/docs/en/compute-edition/32/admin-guide/vulnerability-management/vm-image-scanning.adoc
![AMI-scanning](https://github.com/hlxsites/prisma-cloud-docs/assets/105501696/184894ff-e209-442a-be41-f0df63cb07b5)


Fix #586 

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://jjeanclaude--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=jjeanclaude
