### PR TITLE
[CAS] CI/CD System docs - Added support for Azure Pipelines, GitLab CI and BB Data Center  

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/ci-cd-systems/ci-cd-systems.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/ci-cd-systems/ci-cd-systems.adoc
@@ -35,7 +35,7 @@ NOTE: Bitbucket Server supports the Cloud Code Security module, but not the CI/C
 |No
 
 |Azure Pipelines
-|VCS
+|CI/CD
 |Yes
 |No
 
@@ -70,7 +70,7 @@ NOTE: Bitbucket Server supports the Cloud Code Security module, but not the CI/C
 |Yes
 
 |GitLab CI
-|VCS
+|CI/CD
 |Yes
 |Yes
 

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/ci-cd-systems/ci-cd-systems.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/ci-cd-systems/ci-cd-systems.adoc
@@ -20,51 +20,65 @@ Integrate Prisma Cloud with your CI/CD systems in order to gain visibility into,
 
 The following table provides an inventory of the systems that currently support out-of-the-box CI/CD scanning when integrated with Prisma Cloud.
 
+////
 NOTE: Bitbucket Server supports the Cloud Code Security module, but not the CI/CD Security module. Consequently, integrated repositories will not be visible on the *Application Security > Repositories*.
+////
 
 [cols="1,1,1,1" frame=sides]
 |===
 
 |System |Type |SaaS |On-Prem
 
-|GitHub
+|Azure Repos
 |VCS
 |Yes
-|Yes
+|No
 
-|GitLab
+|Azure Pipelines
 |VCS
 |Yes
-|Yes
-
+|No
 
 |Bitbucket
 |VCS
 |Yes
 |No
 
-
-|Azure Repos
+|Bitbucket Data Center/Server
 |VCS
 |Yes
 |No
 
+|CircleCI
+|CI/CD
+|Yes
+|No
+
+|GitHub
+|VCS
+|Yes
+|Yes
 
 |GitHub Actions
 |CI/CD
 |Yes
 |No
 
+|GitLab
+|VCS
+|Yes
+|Yes
+
+|GitLab CI
+|VCS
+|Yes
+|Yes
 
 |Jenkins
 |CI/CD
 |N/A
 |Yes
 
-|CircleCI
-|CI/CD
-|Yes
-|No
 
 |===
 

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/ci-cd-systems/ci-cd-systems.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/ci-cd-systems/ci-cd-systems.adoc
@@ -27,7 +27,7 @@ NOTE: Bitbucket Server supports the Cloud Code Security module, but not the CI/C
 [cols="1,1,1,1" frame=sides]
 |===
 
-|System |Type |SaaS |On-Prem
+|*System* |*Type* |*SaaS* |*On-Prem*
 
 |Azure Repos
 |VCS


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/BCE-33109

Added GitLab CI and Azure Pipelines to the list of sy=upported systems for CI/CD Systems. In addition removed the limitation for BB Data Center, adding this system to the list of supported systems


Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
