### PR TITLE
[CAS] BB Data Center Added caveat to tokens, requiring admin permissions for CI/CD scans

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket-server.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket-server.adoc
@@ -32,7 +32,7 @@ NOTE: Refer to <<#subscribed-events,Subscribed Events>> below for a list of even
 .. Provide a *Token name*.
 .. Select the *Permissions* scope.
 +
-* For Projects: *Read* permissions
+* For Projects: *Read* permissions. If you require for CI/CD scanning capabilities, select *Administrator* permissions
 * For Repositories: *Administrator* permissions
 +
 Providing read and write permissions to the necessary repositories enables Prisma Cloud to copy files for scanning, and access repository settings. This, in turn, facilitates the ability to subscribe to pull request (PR) webhooks, allowing for the initiation of fix PRs and comments on open PRs.
@@ -172,6 +172,7 @@ Authorize the user integrating Prisma Cloud with your Bitbucket Server/Data Cent
 * *Read* permissions for projects
 * *Administrator* permissions for repositories
 
+[#ci-cd-permissions]
 ==== CI/CD Module Permissions
 
 * *Administrator* permissions for projects


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/BCE-33388

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
