### PR TITLE
Update serverless.adoc

### DIFF
--- a/docs/en/classic/compute-admin-guide/install/deploy-defender/serverless/serverless.adoc
+++ b/docs/en/classic/compute-admin-guide/install/deploy-defender/serverless/serverless.adoc
@@ -25,7 +25,7 @@ See xref:../../system-requirements.adoc#serverless-runtimes[system requirements]
 The following runtimes are supported for AWS Lambda:
 
 * C# (.NET Core) 6.0
-* Java 8, 11
+* Java 8, 11, 17, 21
 * Node.js 14.x, 16.x, 18.x
 * Python 3.6, 3.7, 3.8, 3.9
 * Ruby 2.7
@@ -187,7 +187,7 @@ After embedding Serverless Defender, update the name of the handler registered w
 Prisma Cloud supports both service struct and stream input (serialized struct).
 Even though the Context parameter is optional for unprotected functions, it's manadatory when embedding Serverless Defender.
 
-Prisma Cloud supports Java 8 and Java 11.
+Prisma Cloud supports Java 8, Java 11, Java 17 and Java 21.
 
 [.procedure]
 . Open Compute Console, and go to *Manage > Defenders > Defenders: Deployed > Manual Deploy > Single Defender*.


### PR DESCRIPTION
Our API docs indicate that we also support Java 17 and 21.

https://pan.dev/prisma-cloud/api/cwpp/post-images-twistlock-defender-layer-zip/

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
