### PR TITLE
[Governance] Added supported scan types for Attribute Operators in Code Editors

### DIFF
--- a/docs/en/enterprise-edition/content-collections/governance/custom-build-policies/code-editor.adoc
+++ b/docs/en/enterprise-edition/content-collections/governance/custom-build-policies/code-editor.adoc
@@ -55,85 +55,111 @@ For instructions on how to use the type of Attribute with key and values see in 
 
 For instructions on how to use Attribute Operators see in the table.
 
-[cols="1,2", options="header"]
+[cols="1,1,1", options="header"]
 |===
 |Attribute  Operators
 |YAML values
+|Supported Scan Type
 
 |Equals
 |`equals`
+|IaC
 
 |Not Equals
 |`not_equals`
+|IaC
 
 |Regex Match
 |`regex_match`
+|IaC, Secrets
 
 |Not Regex Match
 |`not_regex_match`
+|IaC, Secrets
 
 |Exists
 |`exists`
+|IaC
 
 |Not Exists
 |`not_exists`
+|IaC
 
 |One Exists
 |`one_exists`
+|IaC
 
 |Any
 |`any`
+|IaC
 
 |Contains
 |`contains`
+|IaC
 
 |Not Contains
 |`not_contains`
+|IaC
 
 |Within
 |`within`
+|IaC
 
 |Starts With
 |`starting_with`
+|IaC
 
 |Not Starts With
 |`not_starting_with`
+|IaC
 
 |Ends With
 |`ending_with`
+|IaC
 
 |Not Ends With
 |`not_ending_with`
+|IaC
 
 |Greater Than
 |`greater_than`
+|IaC
 
 |Greater Than Or Equal
 |`greater_than_or_equal`
+|IaC
 
 |Less Than
 |`less_than`
+|IaC
 
 |Less Than Or Equal
 |`less_than_or_equal`
+|IaC
 
 |Subset
 |`subset`
+|IaC
 
 |Not Subset
 |`not_subset`
+|IaC
 
 |Json Path Equals
 |`jsonpath_equals`
+|IaC
 
 |Json Path Exists
 |`jsonpath_exists`
+|IaC
 
 |Intersects
 |`intersects`
+|IaC
 
 |Not Intersects
 |`not_intersects`
+|IaC
 
 |===
 


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/BCE-33624

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
