### PR TITLE
[CAS] Added organization owner permissions to all VCS integrations except GitHub SaaS

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-azurerepos.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-azurerepos.adoc
@@ -131,7 +131,11 @@ NOTE: You cannot delete the integration from *Repositories* for an account integ
 
 Authorize the user integrating Prisma Cloud with your Azure Repos instance with the following permissions.
 
-* *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
+* *Organization owner* permissions
+
+* *Project Administrator*: This permission is required to subscribe to webhooks. For more information refer to the Microsoft https://learn.microsoft.com/en-us/azure/devops/service-hooks/overview?view=azure-devops#q-what-permissions-do-i-need-to-set-up-a-subscription[Integrate with service hooks] documentation
+
+* *Administrator repository* permissions: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
 
 * *Identity (read) [vso.identity]*: This permission grants read access to identity-related information or configurations within Azure DevOps. It allows the user to view details about users, groups, or other identity-related entities
 

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket-server.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket-server.adoc
@@ -169,6 +169,7 @@ image::application-security/bb-id1.1.png[]
 
 Authorize the user integrating Prisma Cloud with your Bitbucket Server/Data Center instance with the following permissions.
 
+* *Organization owner* permissions
 * *Read* permissions for projects
 * *Administrator* permissions for repositories
 

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-bitbucket.adoc
@@ -98,6 +98,8 @@ On *Code & Build Providers*, you can also manage the integration by reselection 
 
 Authorize the user integrating Prisma Cloud with your Bitbucket instance with the following permissions.
 
+* *Organization owner* permissions
+
 * *project*: Provides access to view the project or projects. This scope implies the `repository` scope, giving read access to all the repositories in a project or projects. 
 
 * *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-github-server.adoc
@@ -86,6 +86,8 @@ NOTE: It may take up to 3 minutes for the integration status to be updated.
 
 Authorize the user integrating Prisma Cloud with your GitHub Server instance with the following permissions.
 
+* *Organization owner* permissions
+
 * *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 
 
 * *repo*: Grants full access to public and private repositories, including read and write access to code, commit statuses, repository invitations, collaborators, deployment statuses, and the capability to subscribe the repository to receive new webhook notifications or events

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab-selfmanaged.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab-selfmanaged.adoc
@@ -138,6 +138,8 @@ Manage integrations from the integration wizard.
 
 Authorize the user integrating Prisma Cloud with your GitLab Self-managed instance with the following permissions.
 
+* *Organization owner* permissions
+
 * *api*: Grants full *read* and *write* access to the API, including all groups and projects, as well as permissions to interact with the container registry, the dependency proxy, and the package registry
 
 * *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 

--- a/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/get-started/connect-code-and-build-providers/code-repositories/add-gitlab.adoc
@@ -105,6 +105,8 @@ Manage integrations from the integration wizard.
 
 Authorize the user integrating Prisma Cloud with your GitLab instance with the following permissions.
 
+* *Organization owner* permissions
+
 * *api*: Grants full *read* and *write* access to the API, including all groups and projects, as well as permissions to interact with the container registry, the dependency proxy, and the package registry
 
 * *Administrator repository permissions*: In order to scan pull requests (PRs), the user performing the integration must have administrative privileges for the repositories. This enables Prisma Cloud to set up subscription webhooks for the selected repositories 


### PR DESCRIPTION
…. Added project admin permissions to azure integration for webhooks

Jira ticket: https://redlock.atlassian.net/browse/BCE-33648

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
