### PR TITLE
[Runtime Security] Fix Syntax for CWP-55880

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/audit/review-debug-logs.adoc
+++ b/docs/en/compute-edition/32/admin-guide/audit/review-debug-logs.adoc
@@ -13,7 +13,9 @@ The simplest way to view Console's debug logs is from *Manage > Logs > Console* 
 ==== Send Debug Logs to Syslog
 
 You can also send console logs directly to a syslog server. This can be an efficient way to manage logs, especially when consolidating data for analysis.
+
 * Secure Transmission with TLS Certificate: If you provide a TLS certificate on *Manage > Alerts > Logging* and *Syslog* is set to *Enabled*, the logs will be sent securely over HTTPS, ensuring that your data is encrypted during transit and protected from unauthorized access. See xref:logging.adoc[Sending syslog messages to a network endpoint] for more information.
+
 * Standard Transmission without TLS Certificate: Without a TLS certificate, the logs will be sent over HTTP, which is not secured. This method is faster but does not encrypt the data.
 
 === Collect Defender debug logs

--- a/docs/en/enterprise-edition/content-collections/runtime-security/audit/review-debug-logs.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/audit/review-debug-logs.adoc
@@ -13,7 +13,9 @@ The simplest way to view Console's debug logs is from *Manage > Logs > Console* 
 ==== Send Debug Logs to Syslog
 
 You can also send console logs directly to a syslog server. This can be an efficient way to manage logs, especially when consolidating data for analysis.
+
 * Secure Transmission with TLS Certificate: If you provide a TLS certificate on *Manage > Alerts > Logging* and *Syslog* is set to *Enabled*, the logs will be sent securely over HTTPS, ensuring that your data is encrypted during transit and protected from unauthorized access. See xref:logging.adoc[Sending syslog messages to a network endpoint] for more information.
+
 * Standard Transmission without TLS Certificate: Without a TLS certificate, the logs will be sent over HTTP, which is not secured. This method is faster but does not encrypt the data.
 
 === Collect Defender debug logs


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix: Patch for #626 

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
