### PR TITLE
Update product-architecture.adoc

### DIFF
--- a/docs/en/compute-edition/32/admin-guide/welcome/product-architecture.adoc
+++ b/docs/en/compute-edition/32/admin-guide/welcome/product-architecture.adoc
@@ -67,6 +67,7 @@ image::prisma_cloud_arch1.png[width=800]
 
 The following screenshot shows the Compute tab on Prisma Cloud.
 To access the Compute tab, you must log in to the Prisma Cloud administrative console; it cannot be directly addressed in the browser.
+
 image::prisma_cloud_arch2.png[width=800]
 
 You can find the address of Compute Console in Prisma Cloud under *Compute > Manage > System > Utilities*.


### PR DESCRIPTION
image::prisma_cloud_arch2.png[width=800] wasn't being rendered due to a lack of a newline before it.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
