### PR TITLE
[CAS] Removed JavaScript Lockfile v3 Error Msg from Documentation

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/software-composition-analysis/sca-troubleshoot.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/software-composition-analysis/sca-troubleshoot.adoc
@@ -89,11 +89,6 @@ The table below describes error messages that may be encountered during a failed
 |The SCA scan has detected `Yarn.lock` v2 files. However, this version of the `Yarn.lock` file does not support SCA scans, as it lacks dependency provenance information necessary for accurate vulnerability detection. As a result, the scanner may encounter limitations in analyzing dependencies and identifying vulnerabilities accurately, potentially exposing the project to vulnerabilities. +
 *Solution*: To resolve this issue, consider using a different version of the `Yarn.lock` file that supports SCA scans.
 
-|Package lock JSON v3 not supported
-|PACKAGE_LOCK_JSON_V3_NOT_SUPPORTED
-|The SCA scan has detected a `Package-lock` JSON file in version 3. However, this version of the `Package-lock.json` file does not support SCA scans. As a result, the scanner may encounter limitations in analyzing dependencies and identifying vulnerabilities accurately, potentially exposing the project to vulnerabilities. +
-*Solution*: To resolve this issue, consider using a different version of the lock JSON that supports SCA scans.
-
 |Multiple groups detected in Package-lock file
 |PACKAGE_LOCK_SUPPORT_SINGLE_GROUP
 |Multiple lock file groups were detected in the `Package-lock` file of the repository. The SCA scanner is designed to handle single groups exclusively, and does not support multiple groups. As a result, vulnerabilities or issues within these multiple groups will not be detected or analyzed by the scanner, potentially leaving the system vulnerable to security risks. +


### PR DESCRIPTION
This format is now supported.

Jira ticket: https://redlock.atlassian.net/browse/BCE-33820

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
