### PR TITLE
Update configure-gcp.adoc

### DIFF
--- a/docs/en/enterprise-edition/content-collections/runtime-security/agentless-scanning/configure-accounts/configure-gcp.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/agentless-scanning/configure-accounts/configure-gcp.adoc
@@ -157,6 +157,12 @@ gcloud projects add-iam-policy-binding KMS_PROJECT_ID \
 . Replace `KMS_PROJECT_ID` with any project you need to use.
 The KMS project isn't required to be the hub account or the target accounts you wish to scan.
 
+=== Known Limitations
+
+* LVM-based Machine Images: Due to the lack of an official LVM-based Machine Images on GCP, agentless scanning might not recognize and scan AMIs using a non-standard LVM configuration. These machine images will currently not be supported for agentless scanning.
+
+* Unsupported Marketplace Machine Images: Certain machine images available on the GCP Marketplace are configured in a way that prohibits mounting them as secondary volumes. Consequently, agentless scanning is not compatible with these images. If scanning is essential for such hosts, please contact the vendor of the specific machine image to request a configuration change that will enable agentless to scan instances launched from that machine image, by removing that limitation.
+
 === Troubleshooting
 
 If you have organization-level policies blocking external connections, GCP applies the policies at the project level, which includes all the VMs in the applicable projects.


### PR DESCRIPTION
Added known limitations for the lack of LVM support for agentless scans on GCP.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
