### PR TITLE
[CAS] Ansible scan support for IaC misconfigurations 

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
@@ -2,7 +2,7 @@
 
 Integrate the Prisma Cloud Code Security plugin into your workflow with your IDE to directly scan your infrastructure-as-code (IaC) files for misconfigurations, detect vulnerabilities in your software composition analysis (SCA) packages, identify exposed secrets, and uncover license violations while coding. 
 
- For a list of supported technologies refer to xref:supported-technologies.adoc[Supported Technologies].
+For a list of supported technologies refer to xref:../supported-technologies.adoc[Supported Technologies].
 
 This process seamlessly runs in the background without disrupting your coding experience. Remediation options include fixing, suppressing, or referring to documentation. Supported IDEs include VS Code and all JetBrains offerings (such as IntelliJ, PyCharm and so on).
 

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
@@ -1,6 +1,10 @@
 == Integrate Prisma Cloud Code Security Plugin with IDEs
 
-Integrate the Prisma Cloud Code Security plugin into your workflow with your IDE to directly scan your infrastructure-as-code (IaC) files for misconfigurations, detect vulnerabilities in your software composition analysis (SCA) packages, identify exposed secrets, and uncover license violations while coding. This process seamlessly runs in the background without disrupting your coding experience. Remediation options include fixing, suppressing, or referring to documentation. Supported IDEs include VS Code and all JetBrains offerings (such as IntelliJ, PyCharm and so on).
+Integrate the Prisma Cloud Code Security plugin into your workflow with your IDE to directly scan your infrastructure-as-code (IaC) files for misconfigurations, detect vulnerabilities in your software composition analysis (SCA) packages, identify exposed secrets, and uncover license violations while coding. 
+
+ For a list of supported technologies refer to xref:../supported-technologies.adoc[Supported Technologies].
+
+This process seamlessly runs in the background without disrupting your coding experience. Remediation options include fixing, suppressing, or referring to documentation. Supported IDEs include VS Code and all JetBrains offerings (such as IntelliJ, PyCharm and so on).
 
 NOTE: Not all remediation options are available for all findings or all type of scan category.
 

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
@@ -2,7 +2,7 @@
 
 Integrate the Prisma Cloud Code Security plugin into your workflow with your IDE to directly scan your infrastructure-as-code (IaC) files for misconfigurations, detect vulnerabilities in your software composition analysis (SCA) packages, identify exposed secrets, and uncover license violations while coding. 
 
- For a list of supported technologies refer to xref:../supported-technologies.adoc[Supported Technologies].
+ For a list of supported technologies refer to xref:supported-technologies.adoc[Supported Technologies].
 
 This process seamlessly runs in the background without disrupting your coding experience. Remediation options include fixing, suppressing, or referring to documentation. Supported IDEs include VS Code and all JetBrains offerings (such as IntelliJ, PyCharm and so on).
 

--- a/docs/en/enterprise-edition/content-collections/application-security/supported-technologies.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/supported-technologies.adoc
@@ -60,6 +60,11 @@ Prisma Cloud Application Security supports the following package managers and la
 |Terraform
 |Terraform Plan
 
+|Ansible
+|-
+|-
+|-
+
 |===
 
 [#sca-package-support]


### PR DESCRIPTION
Jira ticket: https://redlock.atlassian.net/browse/BCE-34817

Prisma Cloud now offers support for scanning Ansible, an Infrastructure as Code (IaC) framework

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
