### PR TITLE
Update scan-serverless-functions.adoc

### DIFF
--- a/docs/en/enterprise-edition/content-collections/runtime-security/vulnerability-management/scan-serverless-functions.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/vulnerability-management/scan-serverless-functions.adoc
@@ -35,7 +35,7 @@ The Prisma Cloud console performs the following steps to scan serverless functio
 . Identifies all serverless functions.
 . Extracts a function using the appropriate `GET` method sending it to the Prisma Cloud console.
 . Scans the function's code using Palo Alto Networks proprietary methods.
-. Writes the scan results to the the Prisma Cloud console. You can see the results under *Monitor > Vulnerabilities > Functions > Scanned functions*.
+. Writes the scan results to the Prisma Cloud console. You can see the results under *Monitor > Vulnerabilities > Functions > Scanned functions*.
 . Deletes the function code after the scan is completed.
 . Validates that the function code is deleted from the Prisma Cloud console.
 


### PR DESCRIPTION
Typo changed in line 38 to remove second "the"

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
