### PR TITLE
[CAS] Removed redundant list of supported SCA package managers in Supported Technologies 

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/supported-technologies.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/supported-technologies.adoc
@@ -6,7 +6,7 @@ Prisma Cloud Application Security supports the following technologies and framew
 
 Prisma Cloud Application Security supports the following package managers and languages. For a list of supported package managers for Software Composition Analysis, refer to <<#sca-package-support,Supported Package Managers for Software Composition Analysis (SCA)>> below.
 
-
+////
 [cols="1,1"]
 |===
 |Package Manager and Language|Details
@@ -39,6 +39,7 @@ Prisma Cloud Application Security supports the following package managers and la
 |composer.json, composer.lock
 
 |===
+////
 
 === Supported IaC Frameworks
 
@@ -108,7 +109,7 @@ For SCA scans, Prisma Cloud supports the following package managers.
 
 1.2+|Java
 |Maven
-|pom.xml
+|pom.xml (including parent POMs)
 |✔️
 |✔️
 
@@ -117,6 +118,7 @@ a|
 
 build.gradle
 gradle.properties
+gradle-wrapper.properties
 |✔️
 |✔️
 
@@ -161,6 +163,7 @@ npm-shrinkwrap.json
 a|
 Gemfile
 gemfile.lock
+Gemspec
 |✔️
 |✔️
 


### PR DESCRIPTION
Jira ticket: (https://redlock.atlassian.net/browse/BCE-35263)

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
