### PR TITLE
[trivial] Fix BitBucket API URL for unrotated-access-key policy

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/ci-cd-pipeline-policies/bitbucket-cicd-pipeline-policies/bb-unrotate-accesskey.adoc
+++ b/docs/en/enterprise-edition/policy-reference/ci-cd-pipeline-policies/bitbucket-cicd-pipeline-policies/bb-unrotate-accesskey.adoc
@@ -44,7 +44,7 @@ There are two options for creating and deploying keys:
 
 * Create and delete access keys using the console: Browse to the **Access Keys** tab under the repository settings.
 
-* Create and delete deploy keys using the API. Refer to the Bitbucket API documentation: https://docs.gitlab.com/ee/api/deploy_keys.html.
+* Create and delete deploy keys using the API. Refer to the Bitbucket API documentation: https://developer.atlassian.com/cloud/bitbucket/rest/api-group-deployments/#api-repositories-workspace-repo-slug-deploy-keys-get.
 
 
 


### PR DESCRIPTION
Changing the URL for BitBucket Rest API from to point towards the right one. Previous URL was for GitLab