### PR TITLE
[trivial][bc-azure-216] Fix example to reference appropriate resource type

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/azure-policies/azure-networking-policies/bc-azure-216.adoc
+++ b/docs/en/enterprise-edition/policy-reference/azure-policies/azure-networking-policies/bc-azure-216.adoc
@@ -38,8 +38,8 @@ To fix the issue, you should set the `threat_intel_mode` attribute to `Deny` for
 
 [source,go]
 ----
-resource "azurerm_firewall_policy" "example" {
-  name                = "example"
+resource "azurerm_firewall" "example" {
+  name              = "example"
   ...
   threat_intel_mode = "Deny"
 }


### PR DESCRIPTION
The example in this documentation should be referencing an `azurerm_firewall` resource not an `azurerm_firewall_policy` resource.

Here's the current doc should you care to reference: https://docs.prismacloud.io/en/enterprise-edition/policy-reference/azure-policies/azure-networking-policies/bc-azure-216