### PR TITLE
[trivial] Update policy details to reflect updates to azurerm provider

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/azure-policies/azure-kubernetes-policies/ensure-that-aks-uses-azure-policies-add-on.adoc
+++ b/docs/en/enterprise-edition/policy-reference/azure-policies/azure-kubernetes-policies/ensure-that-aks-uses-azure-policies-add-on.adoc
@@ -38,17 +38,23 @@ Azure Policy Add-on for AKS extends Gatekeeper v3, an admission controller webho
 
 
 * *Resource:* azurerm_kubernetes_cluster
-* *Arguments:* addon_profile.azure_policy.enabled
+* *Arguments:*
+** Since azurerm provider v2.97.0: azure_policy_enabled
+** Up to and including azurerm provider v2.96.0: addon_profile.azure_policy.enabled
 
 
 [source,go]
 ----
 resource "azurerm_kubernetes_cluster" "example" {
-                  ...
-+                  addon_profile {
-+                    azure_policy {
-+                      enabled = true
-                    }
-                  }         
-                }
+  ...
+# Since azurerm provider v2.97.0:
++   azure_policy_enabled = true
+
+# Up to and including azurerm provider v2.96.0:
++   addon_profile {
++     azure_policy {
++       enabled = true
++     }
++   }
+}
 ----


### PR DESCRIPTION
Updates example documentation to reflect appropriate arguments for more recent versions of the `azurerm` terraform provider.

Here's the `checkov` code which handles both syntaxes for checking sanity: https://github.com/bridgecrewio/checkov/blob/master/checkov/terraform/checks/resource/azure/AKSUsesAzurePoliciesAddon.py

Here's the existing doc if you care to reference: https://github.com/hlxsites/prisma-cloud-docs/blob/main/docs/en/enterprise-edition/policy-reference/azure-policies/azure-kubernetes-policies/ensure-that-aks-uses-azure-policies-add-on.adoc
