### PR TITLE
[Dig docs] Fix empty pages

### DIFF
--- a/docs/en/enterprise-edition/content-collections/data-security-posture-management/api-documentation/authenticate-and-call-your-first-api.adoc
+++ b/docs/en/enterprise-edition/content-collections/data-security-posture-management/api-documentation/authenticate-and-call-your-first-api.adoc
@@ -2,6 +2,5 @@
 
 .Fragment
 |===
-| https://main\--prisma-cloud-docs-website\--hlxsites.hlx.page/en/enterprise-edition/dspm/authentcate-and-call-your-first-api
-
+| https://main\--prisma-cloud-docs-website\--hlxsites.hlx.page/en/enterprise-edition/dspm/authenticate-and-call-your-first-api
 |===

--- a/docs/en/enterprise-edition/content-collections/data-security-posture-management/troubleshooting/gcp-monitoring-issues.adoc
+++ b/docs/en/enterprise-edition/content-collections/data-security-posture-management/troubleshooting/gcp-monitoring-issues.adoc
@@ -2,5 +2,5 @@
 
 .Fragment
 |===
-| https://main\--prisma-cloud-docs-website\--hlxsites.hlx.page/en/enterprise-edition/dspm/ogcp-monitoring-issues
+| https://main\--prisma-cloud-docs-website\--hlxsites.hlx.page/en/enterprise-edition/dspm/gcp-monitoring-issues
 |===


### PR DESCRIPTION
Fix empty pages

For content-collections/data-security-posture-management/api-documentation/authenticate-and-call-your-first-api.adoc:

* Fix broken table syntax
* Fix mispelled Gdoc file name
