### PR TITLE
Update the doc for alert status reason info and rename file to say Status Reason instead of Resolution Reason...

### DIFF
--- a/docs/en/enterprise-edition/content-collections/alerts/prisma-cloud-alert-status-reasons.adoc
+++ b/docs/en/enterprise-edition/content-collections/alerts/prisma-cloud-alert-status-reasons.adoc
@@ -1,8 +1,10 @@
 [#id97d61277-e387-43b1-8a54-ec644bc02fdc]
-== Prisma Cloud Alert Resolution Reasons
-Review the different reasons an alert is closed on Prisma Cloud
+== Prisma Cloud Alert Status Reasons
+Review the different reasons for why an alert is in open or resolved status on Prisma Cloud.
 
 When an open alert is resolved, the reason that was alert was closed is included to help with audits. The reason is displayed in the response object in the API, and on the Prisma Cloud administrative console on *Alerts > Overview* when you select an resolved alert and review the alert details for the violating resource.
+
+Some common reasons in the below list are also applicable for when an alert is newly opened or re-opened from resolved status.
 
 The table below lists the reasons:
 
@@ -17,11 +19,11 @@ The table below lists the reasons:
 
 
 |RESOURCE_UPDATED
-|Resource was updated (based on the JSON metadata).This status indicates that a change was detected in one of the clauses included in a single or join policy statement within the policy RQL. With this resource update, the policy violation is no longer valid and the alert was resolved.
+|Resource was updated (based on the JSON metadata). This status indicates that a change was detected in one of the clauses included in a single or join policy statement within the policy RQL. If the alert is now in resolved status, then this reason denotes that the policy violation is no longer valid due to an update to the underlying resource. If the alert is in open status, then this reason denotes that the policy violation is now valid due to an update to the underlying resource.
 
 
 |POLICY_UPDATED
-|Policy was updated. This status indicates a change in the policy RQL that results in a resource not being in scope for the policy evaluation.
+|Policy was updated. If alert is resolved, this reason indicates a change in the policy RQL that results in a resource not being in scope for the policy evaluation. If the alert is in open status, this reason indicates that a policy update resulted in resource being in the scope of the policy evaluation and failed the evaluation.
 
 
 |POLICY_DISABLED


### PR DESCRIPTION
…-cloud-alert-resolution-reasons.adoc to prisma-cloud-alert-status-reasons.adoc

- Updated the doc for correct alert status reason info as the current doc was mentioning the reason details for only resolved alerts BUT some of the reasons are also applicable to OPEN alerts
- Renamed the file prisma-cloud-alert-resolution-reasons.adoc to prisma-cloud-alert-status-reasons.adoc to correct naming convention

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
