### PR TITLE
Update bc-gcp-general-1.adoc

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/google-cloud-policies/google-cloud-general-policies/bc-gcp-general-1.adoc
+++ b/docs/en/enterprise-edition/policy-reference/google-cloud-policies/google-cloud-general-policies/bc-gcp-general-1.adoc
@@ -53,7 +53,7 @@ resource "google_sql_database_instance" "main" {
     # type. See argument reference below.
     tier = "db-f1-micro"
     ip_configuration {
-        require_ssl = true
+        ssl_mode = "TRUSTED_CLIENT_CERTIFICATE_REQUIRED"
     }
   }
 }


### PR DESCRIPTION
Updated policy CKV_GCP_6 to use **ssl_mode** attribute instead of deprecated **require_ssl** attribute. Documentation update required to suggest a valid fix. Support for require_ssl was [removed in  Terraform Google Provider v6.0.1](https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/version_6_upgrade#settingsip_configurationrequire_ssl-is-now-removed-in-601)

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix [#6703](https://github.com/bridgecrewio/checkov/pull/6703)
