### PR TITLE
Update serverless.adoc

### DIFF
--- a/docs/en/enterprise-edition/content-collections/runtime-security/install/deploy-defender/serverless/serverless.adoc
+++ b/docs/en/enterprise-edition/content-collections/runtime-security/install/deploy-defender/serverless/serverless.adoc
@@ -19,14 +19,6 @@ Prisma Cloud supports AWS Lambda functions (Linux) and Azure Functions (Windows 
 
 See xref:../../system-requirements.adoc#serverless-runtimes[system requirements] for the runtimes and architectures that are supported for Serverless Defenders.
 
-The following runtimes are supported for AWS Lambda:
-
-* C# (.NET Core) 6.0
-* Java 8, 11
-* Node.js 14.x, 16.x, 18.x
-* Python 3.6, 3.7, 3.8, 3.9
-* Ruby 2.7
-
 Serverless Defenders are not supported on ARM64 architecture.
 
 The following runtimes are supported for Azure Functions (Windows and 64 bit only):


### PR DESCRIPTION
Remove misleading supported versions list which is never kept up-to-date as to rely on the above system requirements link which is kept up to date.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
