### PR TITLE
Update getting-started.adoc

### DIFF
--- a/docs/en/compute-edition/33/admin-guide/welcome/getting-started.adoc
+++ b/docs/en/compute-edition/33/admin-guide/welcome/getting-started.adoc
@@ -36,7 +36,8 @@ endif::compute_edition[]
 
 [.section]
 === Install a test application
-Use your own app or check out the https://microservices-demo.github.io/[Sock Shop].
+Use your own app or check out the https://microservices-demo.github.io/[Sock Shop]. <-- Broken link "There isn't a GitHub Pages site here."
+
 
 [.section]
 === Explore Prisma Cloud's core features


### PR DESCRIPTION
The Sock Shop repo no longer exists.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
