### PR TITLE
Add new NAT IPs

### DIFF
--- a/docs/en/enterprise-edition/content-collections/get-started/console-prerequisites.adoc
+++ b/docs/en/enterprise-edition/content-collections/get-started/console-prerequisites.adoc
@@ -1,15 +1,15 @@
 == Enable Access to the Prisma Cloud Console
 // List of NAT Gateway IP addresses for Prisma® Cloud and the URLs/domains that you must add to an allow list.
 
-Allow the following IP addresses and hostnames, used by the different components that comprise Prisma Cloud to ensure contiuned connectivity and monitoring of your cloud environments. 
+Allow the following IP addresses and hostnames, used by the different components that comprise Prisma Cloud to ensure contiuned connectivity and monitoring of your cloud environments.
 
-* <<idcb6d3cd4-d1bf-450a-b0ec-41c23a4d4280>>  
-* <<id82dc870f-ce5b-45c9-a196-f4d069cf94a2>>  
+* <<idcb6d3cd4-d1bf-450a-b0ec-41c23a4d4280>>
+* <<id82dc870f-ce5b-45c9-a196-f4d069cf94a2>>
 * xref:../application-security/manage-network-tunnel/manage-network-tunnel.adoc#whitelist-ip-addresses[Whitelist IPs for Transporter and Application Security Integrations]
 
 [#idcb6d3cd4-d1bf-450a-b0ec-41c23a4d4280]
 === NAT Gateway IP Addresses for Prisma Cloud
-Prisma® Cloud uses the following NAT gateway IP addresses. To ensure that you can access Prisma Cloud and the API for any integrations that you enabled between Prisma Cloud and your incidence response workflows, or your agentless deployment or the Prisma Cloud Defenders to communicate with the Prisma Cloud Compute Console, review the list and update the IP addresses in your allow lists. 
+Prisma® Cloud uses the following NAT gateway IP addresses. To ensure that you can access Prisma Cloud and the API for any integrations that you enabled between Prisma Cloud and your incidence response workflows, or your agentless deployment or the Prisma Cloud Defenders to communicate with the Prisma Cloud Compute Console, review the list and update the IP addresses in your allow lists.
 
 In the event of disruption due to a disaster, to help backup data in a timely manner, add the Disaster Recovery (DR) IP addresses to your allow lists.
 
@@ -80,11 +80,11 @@ Required for Transporter and Application Security integrations with network rest
 
 * 3.210.87.2
 
-|*us-east1 (South Carolina)* 
+|*us-east1 (South Carolina)*
 
 Egress: 34.75.54.101
 
-Ingress: 34.74.84.51, 34.139.64.150, 34.139.249.192
+Ingress: 34.23.229.147, 34.74.84.51, 34.74.93.165, 34.139.64.150, 34.139.249.192, 35.185.127.202
 
 |52.25.108.159/32
 
@@ -140,11 +140,11 @@ Required for Transporter and Application Security integrations with network rest
 
 * 3.132.209.81
 
-|*us-east1 (South Carolina)* 
+|*us-east1 (South Carolina)*
 
 Egress: 34.75.54.101
 
-Ingress: 34.74.84.51, 34.139.64.150, 34.139.249.192
+Ingress: 34.23.229.147, 34.74.84.51, 34.74.93.165, 34.139.64.150, 34.139.249.192, 35.185.127.202
 
 |54.176.152.228/32
 
@@ -187,11 +187,11 @@ Required for Transporter and Application Security integrations with network rest
 
 * 44.231.142.62
 
-|*us-west1 (Oregon)* 
+|*us-west1 (Oregon)*
 
-Egress: 34.82.51.12 
+Egress: 34.82.51.12
 
-Ingress: 34.82.138.152, 35.230.69.118, 104.198.109.73
+Ingress: 34.19.57.46, 34.82.138.152, 34.83.186.93, 34.168.3.165, 35.230.69.118, 104.198.109.73
 
 |34.192.147.35/32
 
@@ -246,11 +246,11 @@ Required for Transporter and Application Security integrations with network rest
 
 * 54.215.44.246
 
-|*us-west1 (Oregon)* 
+|*us-west1 (Oregon)*
 
-Egress: 34.82.51.12 
+Egress: 34.82.51.12
 
-Ingress: 34.82.138.152, 35.230.69.118, 104.198.109.73
+Ingress: 34.19.57.46, 34.82.138.152, 34.83.186.93, 34.168.3.165, 35.230.69.118, 104.198.109.73
 
 |3.18.55.196/32
 
@@ -279,11 +279,11 @@ Ingress: 34.82.138.152, 35.230.69.118, 104.198.109.73
 
 18.190.115.80
 
-|*us-east1 (South Carolina)* 
+|*us-east1 (South Carolina)*
 
 Egress: 34.75.54.101
 
-Ingress: 34.74.84.51
+Ingress: 34.23.229.147, 34.74.84.51, 34.74.93.165, 34.139.64.150, 34.139.249.192, 35.185.127.202
 |
 
 
@@ -328,7 +328,7 @@ Required for Transporter and Application Security integrations with network rest
 
 * 54.206.227.53
 
-|*asia-northeast1 (Tokyo, Japan)* or *australia-southeast1 (Sydney, Australia)* 
+|*asia-northeast1 (Tokyo, Japan)* or *australia-southeast1 (Sydney, Australia)*
 
 Egress: 35.194.113.255 or 35.244.121.190
 
@@ -348,7 +348,7 @@ Ingress: 35.200.123.236 or 35.189.44.184
 
 54.64.112.185
 
- 
+
 |*app.ca.prismacloud.io* ca-central-1 (Canada - Central)
 
 |3.97.19.141
@@ -391,7 +391,7 @@ Required for Transporter and Application Security integrations with network rest
 
 * 3.98.207.92
 
-|*northamerica-northeast1 (Montréal, Québec)* 
+|*northamerica-northeast1 (Montréal, Québec)*
 
 Egress: 35.203.59.190
 
@@ -415,7 +415,7 @@ Ingress: 35.203.31.67
 52.83.77.73
 
 |Compute SaaS not supported
-| - 
+| -
 
 
 |*app.ind.prismacloud.io*
@@ -444,7 +444,7 @@ Required for Transporter and Application Security integrations with network rest
 
 * 13.127.213.101
 
-|*asia-south1 (Mumbai)* 
+|*asia-south1 (Mumbai)*
 
 Egress: 35.200.249.161
 
@@ -490,13 +490,13 @@ Required for Transporter and Application Security integrations with network rest
 
 * 3.33.202.249
 
-|*asia-southeast2 (Jakarta)* 
+|*asia-southeast2 (Jakarta)*
 
 Egress: 34.101.179.78, 34.101.75.225, 34.101.158.55
 
 Ingress: 34.101.121.138
 
-| - 
+| -
 
 
 |*app.uk.prismacloud.io* eu-west2 (London)
@@ -525,13 +525,13 @@ Required for Transporter and Application Security integrations with network rest
 
 * 18.133.59.44
 
-|*europe-west2 (London)* 
+|*europe-west2 (London)*
 
 Egress: 34.105.197.208
 
 Ingress: 34.89.87.128
 
-| - 
+| -
 
 
 |*app.eu.prismacloud.io* eu-central-1 (Frankfurt)
@@ -623,11 +623,11 @@ Required for Transporter and Application Security integrations with network rest
 
 18.170.187.88
 
-|*europe-west3 (Frankfurt, Germany)* 
+|*europe-west3 (Frankfurt, Germany)*
 
 Egress: 34.107.65.220
 
-Ingress: 34.107.91.105
+Ingress: 34.107.91.105, 34.141.2.56, 34.141.89.174, 34.141.93.246, 35.198.174.6, 35.198.185.51
 
 |3.65.146.60/32
 
@@ -698,7 +698,7 @@ Ingress: 34.163.186.175
 
 3.32.253.13
 
-3.30.72.123 
+3.30.72.123
 
 3.32.126.62
 
@@ -709,11 +709,11 @@ Ingress: 34.163.186.175
 52.35.163.8
 
 
-|*us-west1 (Oregon)* 
+|*us-west1 (Oregon)*
 
-Egress: 34.82.51.12 
+Egress: 34.82.51.12
 
-Ingress: 34.82.138.152, 35.230.69.118, 104.198.109.73
+Ingress: 34.19.57.46, 34.82.138.152, 34.83.186.93, 34.168.3.165, 35.230.69.118, 104.198.109.73
 |
 
 
@@ -1121,6 +1121,3 @@ Prisma Cloud uses Pendo for in-app analytics.
 ** p.typekit.net
 
 ** {asterisk}.youtube.com
-
-
-


### PR DESCRIPTION
These IPs are intended to be added to our Cloud NAT gateways during the Pascal update 2 release window.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix TLDO-2698

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
