### PR TITLE
Fix CKV_AWS_272 incorrect example

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/bc-aws-272.adoc
+++ b/docs/en/enterprise-edition/policy-reference/aws-policies/aws-general-policies/bc-aws-272.adoc
@@ -36,24 +36,26 @@ This policy ensures that an AWS Lambda function has been properly configured to 
 
 To address the issue, you need to enable the code-signing configuration for your AWS Lambda function. Code-signing adds an extra layer of security to your application by ensuring that the deployed code is not tampered with.
 
-[source,go]
+[source,terraform]
 ----
 resource "aws_lambda_function" "example" {
-  function_name    = "example"
-  filename         = "example.zip"
-  source_code_hash = filebase64sha256("example.zip")
-  handler    = "exports.test"
-  runtime    = "nodejs12.x"
+  function_name = "example"
+  s3_bucket     = aws_signer_signing_job.job.signed_object[0].s3[0].bucket
+  s3_key        = aws_signer_signing_job.this.signed_object[0].s3[0].key
+  handler       = "exports.test"
+  runtime       = "nodejs12.x"
 
 + code_signing_config_arn = aws_lambda_code_signing_config.example.arn
 }
 
 resource "aws_lambda_code_signing_config" "example" {
   allowed_publishers {
-    signing_profile_version_arns = [aws_signer_signing_profile_version.example.arn]
+    signing_profile_version_arns = [aws_signer_signing_profile.example.version_arn]
   }
 
-  policies = "Warn"
+  policies {
+    untrusted_artifact_on_deployment = "Enforce"
+  }
 }
 ----
 


### PR DESCRIPTION
> [!NOTE]
> I'm going through a lot of the Prisma docs and applying the fixes to my team's environment.  I would love to continue creating pull-requests for issues I see, so please let me know if there's any way I can make future PRs easier to review before I make more.

The source for `CKV_AWS_272` has some invalid terraform fields, and improperly references `aws_signer_signing_profile`.
This fix also suggests the reader use an`aws_signer_signing_job` and reference the output as the `s3_bucket` and `s3_key` to be used in the lambda, instead of a local zip.  I didn't want to make the diff way too long and show the full setup.  However, getting AWS Signer to sign your zip and then upload it locally seems a little silly when the functionality can all be automated by Terraform.

I have a few other issues with this check.  It's marked as "HIGH" severity, but I would argue that this is only true if the lambda upload passes through an untrusted step on its way to be uploaded.  If you are defining and zipping the code right there in the terraform, it does act as an extra layer of security, but a very minimal one in most cases.  However, I'm just focusing on the correctness in this PR.

Fix #1041 

Test URLs: (I'm not sure how to set these up for you as an outside contributor)
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
