### PR TITLE
feat: upgrade to v5

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,6 +3,6 @@ Please always provide the [GitHub issue(s)](../issues) your PR is for, as well a
 Fix #<gh-issue-id>
 
 Test URLs:
-- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
-- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
+- Before: https://main--prisma-cloud-docs--hlxsites.aem.page/
+- After: https://<branch>--prisma-cloud-docs--hlxsites.aem.page/
 - Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Asciidoc-based content for Prisma Cloud Docs with CF worker to rewrite into Fran
 See also: [prisma-cloud-docs-website](https://github.com/hlxsites/prisma-cloud-docs-website)
 
 ## Environments
-- Preview: https://main--prisma-cloud-docs--hlxsites.hlx.page/
-- Live: https://main--prisma-cloud-docs--hlxsites.hlx.live/
+- Preview: https://main--prisma-cloud-docs--hlxsites.aem.page/
+- Live: https://main--prisma-cloud-docs--hlxsites.aem.live/
 - Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/
 
 ## Installation

--- a/bin/generate-sitemaps.js
+++ b/bin/generate-sitemaps.js
@@ -15,7 +15,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const SITEMAP_MAX_BYTES = 8 * 1000 * 1000; // 8MB
 const ORIGIN = process.env.ORIGIN || 'https://docs.prismacloud.io';
-const META_SOURCE = 'https://main--prisma-cloud-docs-website--hlxsites.hlx.live/metadata.json';
+const META_SOURCE = 'https://main--prisma-cloud-docs-website--hlxsites.aem.live/metadata.json';
 const LOCALES = ['en', 'jp'];
 const ROOT_PATH = '';
 const DESTINATION = (locale, index) => resolve(__dirname, `../docs/sitemaps/sitemap-${locale}-${index}.xml`);

--- a/bin/preview-changes.js
+++ b/bin/preview-changes.js
@@ -15,7 +15,7 @@ import yaml from 'js-yaml';
 export default async function previewChanges({
   github, context, glob, changes,
 }) {
-  const host = 'https://main--prisma-cloud-docs-website--hlxsites.hlx.page';
+  const host = 'https://main--prisma-cloud-docs-website--hlxsites.aem.page';
   const fallbackPath = '/en';
   const branch = context.payload.pull_request.head.ref;
   const adocChanges = changes.filter((change) => change.endsWith('.adoc'));

--- a/preview/README.md
+++ b/preview/README.md
@@ -5,11 +5,11 @@ and creates a pull request, the preview GitHub action will run and automatically
 site corresponding to the adoc file changes and verify that adoc files referenced in books are not missing in the 
 repository.
 
-The preview functionality is only enabled on `.hlx.page` sites and for local development. It relies on setting the 
+The preview functionality is only enabled on `.aem.page` sites and for local development. It relies on setting the 
 search parameter `?branch=` to the Franklin site URL. The branch value should be the name of the pushed branch in the 
 repository where the documentation stays.
 
-Example URL with branch param: https://main--prisma-cloud-docs-website--hlxsites.hlx.page/en/compute/ops-guide/getting-started/test-sitemap?branch=ian-test-multi-commit-preview.
+Example URL with branch param: https://main--prisma-cloud-docs-website--hlxsites.aem.page/en/compute/ops-guide/getting-started/test-sitemap?branch=ian-test-multi-commit-preview.
 The branch `test-multi-commit-preview` maps to the pushed branch `ian-test-multi-commit-preview` https://github.com/hlxsites/prisma-cloud-docs/tree/ian-test-multi-commit-preview.
 
 Once the PR is merged and the branch is deleted, the preview URL will only display the chapter title.

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -13,7 +13,7 @@ cwd = "worker"
 # watch_dir = "worker/src"
 
 [vars]
-CONTENT_UPSTREAM='https://main--prisma-cloud-docs-website--hlxsites.hlx.page'
+CONTENT_UPSTREAM='https://main--prisma-cloud-docs-website--hlxsites.aem.page'
 # temp using PAN repo as adoc source
 DOC_UPSTREAM='https://raw.githubusercontent.com'
 DOC_REPO_OWNER='hlxsites'
@@ -26,7 +26,7 @@ PREVIEW_REPO_OWNER='hlxsites'
 PREVIEW_REPO_NAME='prisma-cloud-docs'
 
 [env.production.vars]
-CONTENT_UPSTREAM='https://main--prisma-cloud-docs-website--hlxsites.hlx.live'
+CONTENT_UPSTREAM='https://main--prisma-cloud-docs-website--hlxsites.aem.live'
 # temp using PAN repo as adoc source
 DOC_UPSTREAM='https://raw.githubusercontent.com'
 DOC_REPO_OWNER='hlxsites'


### PR DESCRIPTION
ref: https://github.com/hlxsites/prisma-cloud-docs-website/pull/250

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.aem.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.aem.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=v5
