### PR TITLE
Remove outdated IDE permission

### DIFF
--- a/docs/en/enterprise-edition/content-collections/administration/prisma-cloud-administrator-roles.adoc
+++ b/docs/en/enterprise-edition/content-collections/administration/prisma-cloud-administrator-roles.adoc
@@ -18,7 +18,7 @@ An account group administrator can only view assets deployed within the cloud ac
 
 * *Cloud Provisioning Admin*—Permissions to onboard and manage cloud accounts from Prisma Cloud and the APIs, and the ability to create and manage the account groups. With this role access is limited to *Settings > Cloud Accounts* and *Settings > Account Groups* on the admin console.
 
-* *Build and Deploy Security*—Restricted permissions to DevOps users who need access to a subset of *Runtime Security* capabilities and/or API access to run IDE, SCM and CI/CD plugins for Infrastructure as Code and image vulnerabilities scans. For example, the Build and Deploy Security role enables read-only permissions to review vulnerability and compliance scan reports on *runtime security* and to manage and download utilities such as Defender images, plugins and twistcli.
+* *Build and Deploy Security*—Restricted permissions to DevOps users who need access to a subset of *Runtime Security* capabilities and/or API access to run image vulnerabilities scans. For example, the Build and Deploy Security role enables read-only permissions to review vulnerability and compliance scan reports on *runtime security* and to manage and download utilities such as Defender images, plugins and twistcli.
 +
 And if you use the Build and Deploy Security role with *Access key only* enabled, the administrator can create xref:create-access-keys.adoc#idb225a52a-85ea-4b0c-9d69-d2dfca250e16[one access key] to use the Prisma Cloud Runtime Security APIs.
 +


### PR DESCRIPTION
The Build and Deploy role cannot be used for the IDE plugin or SCM integrations since the old IaC tool was deprecated

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.hlx.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.hlx.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
