### PR TITLE
Correcting case and quotes

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/azure-policies/azure-networking-policies/ensure-that-key-vault-allows-firewall-rules-settings.adoc
+++ b/docs/en/enterprise-edition/policy-reference/azure-policies/azure-networking-policies/ensure-that-key-vault-allows-firewall-rules-settings.adoc
@@ -31,7 +31,7 @@
 
 Key vault's firewall prevents unauthorized traffic from reaching your key vault and provides an additional layer of protection for your secrets.
 Enable the firewall to make sure that only traffic from allowed networks can access your key vault.
-By defining "bypass=AzureServices" and "default_action= "deny" - only matched ip_rules and/or virtual_network_subnet_ids will be passed
+By defining *bypass="AzureServices"* and *default_action= "Deny"* - only matched ip_rules and/or virtual_network_subnet_ids will be passed
 
 === Fix - Buildtime
 


### PR DESCRIPTION
Update ensure-that-key-vault-allows-firewall-rules-settings.adoc

Corrected mismatched quotes and changed deny to Deny as the value is case sensitive. It now matches the Terraform code example.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.aem.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.aem.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
