### PR TITLE
[CAS] IDE Added limitation to user names in file paths

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
@@ -8,7 +8,7 @@ This process seamlessly runs in the background without disrupting your coding ex
 
 NOTE: Not all remediation options are available for all findings or all type of scan category.
 
-Limitation: Special characters (such as `&`, parenthesis`()`) are not supported in user names within a file path. For example, the `​é`​ character in `​c:\Users\JohnSmithé`​​ is not supported.
+*Limitation*: Special characters (such as `&`, parenthesis()) are not supported in user names within a file path. For example, the `​é`​ character in `​c:\Users\JohnSmithé`​​ is not supported.
 
 For more information on the Prisma Cloud plugin for *VS Code*, refer to xref:connect-vscode.adoc[VS Code].
 

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
@@ -8,6 +8,8 @@ This process seamlessly runs in the background without disrupting your coding ex
 
 NOTE: Not all remediation options are available for all findings or all type of scan category.
 
+Limitation: Special characters (such as `&`, parenthesis`()`) are not supported in user names within a file path. For example, the `​é`​ character in `​c:\Users\JohnSmithé`​​ is not supported.
+
 For more information on the Prisma Cloud plugin for *VS Code*, refer to xref:connect-vscode.adoc[VS Code].
 
 For more information on the Prisma Cloud plugin for *JetBrains*, refer to xref:connect-jetbrains.adoc[JetBrains].

--- a/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/ides/ides.adoc
@@ -8,7 +8,7 @@ This process seamlessly runs in the background without disrupting your coding ex
 
 NOTE: Not all remediation options are available for all findings or all type of scan category.
 
-*Limitation*: Special characters (such as `&`, parenthesis()) are not supported in user names within a file path. For example, the `​é`​ character in `​c:\Users\JohnSmithé`​​ is not supported.
+*Limitation*: Special characters (such as `&`, parenthesis ()) are not supported in user names within a file path. For example, the `​é`​ character in `​c:\Users\JohnSmithé`​​ is not supported.
 
 For more information on the Prisma Cloud plugin for *VS Code*, refer to xref:connect-vscode.adoc[VS Code].
 


### PR DESCRIPTION
Jira ticket: https://jira-dc.paloaltonetworks.com/browse/BCE-48913

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.aem.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.aem.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
