### PR TITLE
[CAS] Update supported frameworks for missing-lock files under SCA troubleshooting

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/software-composition-analysis/sca-troubleshoot.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/software-composition-analysis/sca-troubleshoot.adoc
@@ -44,7 +44,7 @@ The table below describes error messages that may be encountered during a failed
 
 |[[missing-lock-file]]Missing Lock file 
 |LOCK_FILE_IS_MISSING
-|The lock file provides essential dependency information for SCA scans. Without it, the tool may face challenges in accurately identifying vulnerabilities and comprehensively analyzing both direct and transitive dependencies, potentially compromising the effectiveness of the scan. +
+|The lock file provides essential dependency information for SCA scans. Without it, the tool may face challenges in accurately identifying vulnerabilities and comprehensively analyzing both direct and transitive dependencies, potentially compromising the effectiveness of the scan. Prisma Cloud Application Security supports specific lock files for various ecosystems, including `composer.lock` for *PHP*, `paket.lock` for *.NET (Paket)*, and `package-lock.json` for *JavaScript (NPM)*. +
 *Example*: The `composer.json` file is present, but its lock file is missing. This absence of the lock file can impact the accuracy of vulnerability detection during the SCA scan. +
 *Solution*: Ensure that the lock file exists and is scanned. 
 


### PR DESCRIPTION
Jira ticket: https://jira-dc.paloaltonetworks.com/browse/BCE-50128
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.aem.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.aem.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
