### PR TITLE
Update enforcement.adoc with additional note

### DIFF
--- a/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/enforcement.adoc
+++ b/docs/en/enterprise-edition/content-collections/application-security/risk-management/monitor-and-manage-code-build/enforcement.adoc
@@ -176,6 +176,7 @@ image::application-security/enfor-6.png[]
 . Select the repositories you want to add the exception for.
 +
 NOTE: You will only view repositories that you own.
++
 NOTE: A repository can only belong to one exception. They will not populate in Prisma to be added if they already belong to an exception. The API calls will fail if you attempt to add or update a rule with a repository that exists in another exception.
 
 . Modify the severity threshold corresponding to the required code category/ categories.


### PR DESCRIPTION
I added a note that repositories cannot be a part of multiple exceptions.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix # none

Test URLs:
- Before: https://main--prisma-cloud-docs--hlxsites.aem.page/
- After: https://<branch>--prisma-cloud-docs--hlxsites.aem.page/
- Worker: https://prisma-cloud-docs-production.adobeaem.workers.dev/?branch=<branch>
