### PR TITLE
Documentation correction - Using correct AWS resource and argument

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/aws-policies/aws-networking-policies/ensure-that-load-balancer-networkgateway-has-cross-zone-load-balancing-enabled.adoc
+++ b/docs/en/enterprise-edition/policy-reference/aws-policies/aws-networking-policies/ensure-that-load-balancer-networkgateway-has-cross-zone-load-balancing-enabled.adoc
@@ -43,8 +43,8 @@ This can help to ensure that your application is able to handle more traffic and
 
 [source,go]
 ----
-resource "aws_secretsmanager_secret" "example" {
+resource "aws_lb" "example" {
               name = "example"
- +            kms_key_id = "arn:kuku:kisi"
+ +            enable_cross_zone_load_balancing = true
             }
 ----


### PR DESCRIPTION
The correct resource is '**aws_lb**', and the correct argument is '**enable_cross_zone_load_balancing = true**'