### PR TITLE
docs(gke): update proposed fix to new terraform provider version

### DIFF
--- a/docs/en/enterprise-edition/policy-reference/google-cloud-policies/google-cloud-kubernetes-policies/ensure-the-gke-metadata-server-is-enabled.adoc
+++ b/docs/en/enterprise-edition/policy-reference/google-cloud-policies/google-cloud-kubernetes-policies/ensure-the-gke-metadata-server-is-enabled.adoc
@@ -55,7 +55,7 @@ When unspecified, the default setting allows running pods to have full access to
 
 + node_config {
 +   workload_metadata_config {
-+     node_metadata = "GKE_METADATA_SERVER"
++     mode = "GKE_METADATA"
 +   }
 + }
   


### PR DESCRIPTION
The suggested fix is updated to the arguments for the current google terraform provider version.

The current resource arguments can be found here: 
https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_workload_metadata_config

The old fix does not work with current versions of the provider.
